### PR TITLE
Define selenium2 capabilities as strings

### DIFF
--- a/src/Behat/MinkExtension/services/sessions/selenium2.xml
+++ b/src/Behat/MinkExtension/services/sessions/selenium2.xml
@@ -8,11 +8,11 @@
 
         <parameter key="behat.mink.selenium2.browser">%behat.mink.browser_name%</parameter>
         <parameter key="behat.mink.selenium2.capabilities" type="collection">
-            <parameter key="browserName">firefox</parameter>
-            <parameter key="version">8</parameter>
-            <parameter key="platform">ANY</parameter>
-            <parameter key="browserVersion">8</parameter>
-            <parameter key="browser">firefox</parameter>
+            <parameter key="browserName" type="string">firefox</parameter>
+            <parameter key="version" type="string">8</parameter>
+            <parameter key="platform" type="string">ANY</parameter>
+            <parameter key="browserVersion" type="string">8</parameter>
+            <parameter key="browser" type="string">firefox</parameter>
         </parameter>
         <parameter key="behat.mink.selenium2.wd_host">http://localhost:4444/wd/hub</parameter>
 


### PR DESCRIPTION
After testing https://github.com/Behat/MinkExtension/commit/72760dbc3468cdfc30523b84eb9644b5c8484866, Selenium2 was throwing the following error at the beginning of a test,

java.lang.Long cannot be cast to java.lang.String

This patch explicitly sets parameter types to string.
