### PR TITLE
Scenario Outline was not configuring default Mink session

### DIFF
--- a/src/Behat/MinkExtension/Context/Initializer/MinkAwareInitializer.php
+++ b/src/Behat/MinkExtension/Context/Initializer/MinkAwareInitializer.php
@@ -66,6 +66,7 @@ class MinkAwareInitializer implements InitializerInterface, EventSubscriberInter
     {
         return array(
             'beforeScenario' => 'prepareDefaultMinkSession',
+            'beforeOutline'  => 'prepareDefaultMinkSession',
             'afterSuite'     => 'tearDownMinkSessions'
         );
     }


### PR DESCRIPTION
Scenario Outline was not configuring default Mink session before each scenario, added beforeOutline eventName to SubscribedEvents.

Fixes [Scenario OutLine uses Goutte as default mink driver with Extension](http://groups.google.com/group/behat/browse_thread/thread/4b0c4fa86c00b012)
