### PR TITLE
Fixing use of MinkDictionary

### DIFF
--- a/src/Behat/MinkExtension/Context/MinkDictionary.php
+++ b/src/Behat/MinkExtension/Context/MinkDictionary.php
@@ -5,6 +5,7 @@ namespace Behat\MinkExtension\Context;
 use Behat\Gherkin\Node\TableNode;
 
 use Behat\Mink\Mink,
+    Behat\Mink\Session,
     Behat\Mink\WebAssert;
 
 /*


### PR DESCRIPTION
This is just to get proper autocomplete in IDEs when calling the getSession() method.
