### PR TITLE
Fixing the SelectorsPass - wrong id

### DIFF
--- a/src/Behat/MinkExtension/Compiler/SelectorsPass.php
+++ b/src/Behat/MinkExtension/Compiler/SelectorsPass.php
@@ -29,11 +29,11 @@ class SelectorsPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('behat.mink.selectors_handler')) {
+        if (!$container->hasDefinition('behat.mink.selector.handler')) {
             return;
         }
 
-        $handlerDefinition = $container->getDefinition('behat.mink.selectors_handler');
+        $handlerDefinition = $container->getDefinition('behat.mink.selector.handler');
         foreach ($container->findTaggedServiceIds('behat.mink.selector') as $id => $attributes) {
             foreach ($attributes as $attribute) {
                 if (isset($attribute['alias']) && $alias = $attribute['alias']) {


### PR DESCRIPTION
Hi guys!

This seems like a pretty obvious fix, but I wanted a sanity check first.

The `SelectorsPass` is using an invalid service id, so this pass never really does anything. It doesn't affect anything since since the default `SelectorsHandler` instantiates the 2 default selectors by default anyways, but it makes it impossible to add an additional selector.

Thanks!
