### PR TITLE
Fixed the mink dictionary trait

### DIFF
--- a/src/Behat/MinkExtension/Context/MinkDictionary.php
+++ b/src/Behat/MinkExtension/Context/MinkDictionary.php
@@ -320,7 +320,7 @@ trait MinkDictionary
      */
     public function assertPageMatchesText($pattern)
     {
-        $this->assertSession()->pageTextMatches($this->fixStepArgument($text));
+        $this->assertSession()->pageTextMatches($this->fixStepArgument($pattern));
     }
 
     /**
@@ -330,7 +330,7 @@ trait MinkDictionary
      */
     public function assertPageNotMatchesText($pattern)
     {
-        $this->assertSession()->pageTextNotMatches($this->fixStepArgument($text));
+        $this->assertSession()->pageTextNotMatches($this->fixStepArgument($pattern));
     }
 
     /**


### PR DESCRIPTION
There was a variable rename on the MinkDictionary trait which was done on the header of the function but not on the body of it, thus resulting in an access to an unset variable. This PR fixes it.
