### PR TITLE
Allow relative paths in files_path

### DIFF
--- a/src/Behat/MinkExtension/Context/MinkContext.php
+++ b/src/Behat/MinkExtension/Context/MinkContext.php
@@ -178,7 +178,7 @@ class MinkContext extends RawMinkContext implements TranslatedContextInterface
         $field = $this->fixStepArgument($field);
 
         if ($this->getMinkParameter('files_path')) {
-            $fullPath = rtrim($this->getMinkParameter('files_path'), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$path;
+            $fullPath = rtrim(realpath($this->getMinkParameter('files_path')), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$path;
             if (is_file($fullPath)) {
                 $path = $fullPath;
             }


### PR DESCRIPTION
This will allow paths set in files_path setting in behat.yml to be relative.

If you think that files_path Mink parameter shouldn't be wrapped in realpath before `if (is_file($fullPath))` is executed then I think that it can be moved after the first check is made.
