### PR TITLE
Update src/Behat/MinkExtension/Context/Initializer/MinkAwareInitializer....

### DIFF
--- a/src/Behat/MinkExtension/Context/Initializer/MinkAwareInitializer.php
+++ b/src/Behat/MinkExtension/Context/Initializer/MinkAwareInitializer.php
@@ -65,10 +65,9 @@ class MinkAwareInitializer implements InitializerInterface, EventSubscriberInter
     public static function getSubscribedEvents()
     {
         return array(
-            'beforeScenario' => array('prepareDefaultMinkSession', 10),
-            'beforeOutline'  => array('prepareDefaultMinkSession', 10),
+            'beforeScenario'       => array('prepareDefaultMinkSession', 10),
             'beforeOutlineExample' => array('prepareDefaultMinkSession', 10),
-            'afterSuite'     => array('tearDownMinkSessions', -10)
+            'afterSuite'           => array('tearDownMinkSessions', -10)
         );
     }
 


### PR DESCRIPTION
...php

Session was not reset for the non-first Scenario Outline Example.

Features file example:
Scenario Outline: Check FE pages visible only for logged user

```
Given I am logged customer
And I open "<page_type>" 
Then the response status code should be 200
And I should see no errors

Examples:
| page_type               |
| FEAccount               |
| FEOrderList             |
```
