### PR TITLE
bump desired firefox version from 8 to 9 to match behat.xml

### DIFF
--- a/src/Behat/MinkExtension/Extension.php
+++ b/src/Behat/MinkExtension/Extension.php
@@ -210,13 +210,13 @@ class Extension implements ExtensionInterface
                                     defaultValue('firefox')->
                                 end()->
                                 scalarNode('version')->
-                                    defaultValue(8)->
+                                    defaultValue("9")->
                                 end()->
                                 scalarNode('platform')->
                                     defaultValue('ANY')->
                                 end()->
                                 scalarNode('browserVersion')->
-                                    defaultValue(8)->
+                                    defaultValue("9")->
                                 end()->
                                 scalarNode('browser')->
                                     defaultValue('firefox')->


### PR DESCRIPTION
- bump desired firefox version from 8 to 9 to match behat.xml
- change type from integer to string to fix "java.lang.Long cannot be cast to java.lang.String" error whenever overriding the capabilities, e.g.,

```
# behat.yml
default:
  ...
    Behat\MinkExtension\Extension:
      selenium2:
        capabilities:
          version:  "9"
          browserVersion: "9"
          platform: LINUX
```
