### PR TITLE
add support for WebDriver proxy in desired capabilities

### DIFF
--- a/src/Behat/MinkExtension/Extension.php
+++ b/src/Behat/MinkExtension/Extension.php
@@ -221,6 +221,10 @@ class Extension implements ExtensionInterface
                                 scalarNode('browser')->
                                     defaultValue('firefox')->
                                 end()->
+                                arrayNode('proxy')->
+                                    useAttributeAsKey('key')->
+                                    prototype('variable')->end()->
+                                end()->
                             end()->
                         end()->
                         scalarNode('wd_host')->


### PR DESCRIPTION
In Ubuntu 12.04, Firefox defaults to using the system settings for proxy.

This patch allows users to set the proxy type via config.  (This is an alternative to manipulating Firefox profiles.)

```
# behat.yml
default:
  ...
    Behat\MinkExtension\Extension:
      selenium2:
        capabilities:
          proxy:
            proxyType:    autodetect
```
