### PR TITLE
add remaining Selenium2 webdriver capabilities

### DIFF
--- a/src/Behat/MinkExtension/Extension.php
+++ b/src/Behat/MinkExtension/Extension.php
@@ -234,6 +234,15 @@ class Extension implements ExtensionInterface
                                 scalarNode('browser')->
                                     defaultValue(isset($config['selenium2']['capabilities']['browser']) ? $config['selenium2']['capabilities']['browser'] : 'firefox')->
                                 end()->
+                                booleanNode('javascriptEnabled')->end()->
+                                booleanNode('databaseEnabled')->end()->
+                                booleanNode('locationContextEnabled')->end()->
+                                booleanNode('applicationCacheEnabled')->end()->
+                                booleanNode('browserConnectionEnabled')->end()->
+                                booleanNode('webStorageEnabled')->end()->
+                                booleanNode('rotatable')->end()->
+                                booleanNode('acceptSslCerts')->end()->
+                                booleanNode('nativeEvents')->end()->
                                 arrayNode('proxy')->
                                     useAttributeAsKey('key')->
                                     prototype('variable')->end()->


### PR DESCRIPTION
For completeness.  See: http://code.google.com/p/selenium/wiki/JsonWireProtocol#Capabilities_JSON_Object

Note:  I didn't set a defaultValue because selenium2 has platform-specific defaults (e.g., nativeEvents is false on Linux, but true on Windows);  also, as a side-effect, if a parameter isn't set, it won't appear in the capabilities json object.
