### PR TITLE
Set default value for WebDriver proxy config

### DIFF
--- a/src/Behat/MinkExtension/Extension.php
+++ b/src/Behat/MinkExtension/Extension.php
@@ -244,8 +244,11 @@ class Extension implements ExtensionInterface
                                 booleanNode('acceptSslCerts')->end()->
                                 booleanNode('nativeEvents')->end()->
                                 arrayNode('proxy')->
-                                    useAttributeAsKey('key')->
-                                    prototype('variable')->end()->
+                                    children()->
+                                        scalarNode('proxyType')->
+                                            defaultValue(isset($config['selenium2']['capabilities']['proxy']['proxyType']) ? $config['selenium2']['capabilities']['proxy']['proxyType'] : 'system')->
+                                        end()->
+                                    end()->
                                 end()->
                                 arrayNode('chrome')->
                                     children()->


### PR DESCRIPTION
Since #29, is has became mandatory to define the ProxyType value when using the Chrome webdriver. Not doing so causes a 'Caused by: org.openqa.selenium.WebDriverException: proxy must be of type dictionary, not list. Received: [  ]' error.

This patch sets the default proxy type as per http://code.google.com/p/selenium/wiki/DesiredCapabilities
