### PR TITLE
Selenium2 - proxy patch

### DIFF
--- a/src/Behat/MinkExtension/Extension.php
+++ b/src/Behat/MinkExtension/Extension.php
@@ -245,9 +245,17 @@ class Extension implements ExtensionInterface
                                 booleanNode('nativeEvents')->end()->
                                 arrayNode('proxy')->
                                     children()->
-                                        scalarNode('proxyType')->
-                                            defaultValue(isset($config['selenium2']['capabilities']['proxy']['proxyType']) ? $config['selenium2']['capabilities']['proxy']['proxyType'] : 'system')->
-                                        end()->
+                                        scalarNode('proxyType')->end()->
+                                        scalarNode('proxyAuthconfigUrl')->end()->
+                                        scalarNode('ftpProxy')->end()->
+                                        scalarNode('httpProxy')->end()->
+                                        scalarNode('sslProxy')->end()->
+                                    end()->
+                                    validate()->
+                                        ifTrue(function ($v) {
+                                            return empty($v);
+                                        })->
+                                        thenUnset()->
                                     end()->
                                 end()->
                                 arrayNode('chrome')->


### PR DESCRIPTION
partial revert 37dfaec to not set default (as it is browser-specific)

define the other Proxy JSON options (previously supported implicitly via useAttributeAsKey)

use validation rule to fix #37
