### PR TITLE
Implements saveScreenshot helper method in MinkContext

### DIFF
--- a/src/Behat/MinkExtension/Context/MinkContext.php
+++ b/src/Behat/MinkExtension/Context/MinkContext.php
@@ -477,6 +477,6 @@ class MinkContext extends RawMinkContext implements TranslatedContextInterface
         // No effect in other environments.
         $filename = $filename ?: sprintf('%s_%s_%s.%s', $this->getMinkParameter('browser_name'), date('c'), uniqid('', true), 'png');
         $filepath = $filepath ? $filepath : ini_get('upload_tmp_dir') ? ini_get('upload_tmp_dir') : sys_get_temp_dir();
-        file_put_contents($filepath . '/' . $filename, $this->getSession()->getDriver()->getScreenshot());
+        file_put_contents($filepath . '/' . $filename, $this->getSession()->getScreenshot());
     }    
 }


### PR DESCRIPTION
If the screenshot feature is added in (https://github.com/Behat/Mink/pull/281), then this helper function could go along way towards acceptance.  Given its public nature, testers can easily override it per need, or simply provide parameters.
