### PR TITLE
Allow configuration of additional Sahi connection parameters

### DIFF
--- a/src/Behat/MinkExtension/Extension.php
+++ b/src/Behat/MinkExtension/Extension.php
@@ -185,6 +185,12 @@ class Extension implements ExtensionInterface
                         scalarNode('port')->
                             defaultValue(isset($config['sahi']['port']) ? $config['sahi']['port'] : 9999)->
                         end()->
+                        scalarNode('browser')->
+                            defaultValue(isset($config['sahi']['browser']) ? $config['sahi']['browser'] : null)->
+                        end()->
+                        scalarNode('limit')->
+                            defaultValue(isset($config['sahi']['limit']) ? $config['sahi']['limit'] : 600)->
+                        end()->
                     end()->
                 end()->
                 arrayNode('zombie')->

--- a/src/Behat/MinkExtension/services/sessions/sahi.xml
+++ b/src/Behat/MinkExtension/services/sessions/sahi.xml
@@ -11,6 +11,8 @@
         <parameter key="behat.mink.sahi.sid">null</parameter>
         <parameter key="behat.mink.sahi.host">localhost</parameter>
         <parameter key="behat.mink.sahi.port">9999</parameter>
+        <parameter key="behat.mink.sahi.browser">null</parameter>
+        <parameter key="behat.mink.sahi.limit">600</parameter>
 
     </parameters>
     <services>
@@ -32,6 +34,8 @@
                     <argument>%behat.mink.sahi.sid%</argument>
                     <argument>%behat.mink.sahi.host%</argument>
                     <argument>%behat.mink.sahi.port%</argument>
+                    <argument>%behat.mink.sahi.browser%</argument>
+                    <argument>%behat.mink.sahi.limit%</argument>
                 </service>
             </argument>
         </service>


### PR DESCRIPTION
The values "browser" and "limit" can now be passed in from behat.yml.
