### PR TITLE
Allow ignoreZoomSetting in config

### DIFF
--- a/src/Behat/MinkExtension/Extension.php
+++ b/src/Behat/MinkExtension/Extension.php
@@ -244,6 +244,9 @@ class Extension implements ExtensionInterface
                                 scalarNode('browser')->
                                     defaultValue(isset($config['selenium2']['capabilities']['browser']) ? $config['selenium2']['capabilities']['browser'] : 'firefox')->
                                 end()->
+                                scalarNode('ignoreZoomSetting')->
+                                    defaultValue(isset($config['selenium2']['capabilities']['ignoreZoomSetting']) ? $config['selenium2']['capabilities']['ignoreZoomSetting'] : 'false')->
+                                end()->
                                 scalarNode('name')->
                                     defaultValue(isset($config['selenium2']['capabilities']['name']) ? $config['selenium2']['capabilities']['name'] : 'Behat Test')->
                                 end()->


### PR DESCRIPTION
Hello,

As noted in #41 the Selenium2 IEDriver can take an option called `ignoreZoomSetting`. However the config validation of the extension doesn't allows it.

This PR add support for such option.

This option is really useful when applying Behat/Mink goodness to webapp using the zoom level, typically webapps using ActiveX related stuff (yes, there still are some :))
