### PR TITLE
Add prefs chromedriver capabilities

### DIFF
--- a/src/Behat/MinkExtension/Extension.php
+++ b/src/Behat/MinkExtension/Extension.php
@@ -313,6 +313,7 @@ class Extension implements ExtensionInterface
                                             prototype('scalar')->end()->
                                         end()->
                                         arrayNode('prefs')->
+                                            useAttributeAsKey('key')->
                                             prototype('scalar')->end()->
                                         end()->
                                     end()->


### PR DESCRIPTION
"binary" and "switches" capabilities have been added in ticket #35, but it misses prefs capabilities.

@see http://code.google.com/p/chromedriver/wiki/CapabilitiesAndSwitches#List_of_recognized_capabilities

> prefs: A dictionary with each entry consisting of the name of the preference and its value. These preferences are only applied to the user profile in use. See the 'Preferences' file in Chrome's user data directory for examples.  http://src.chromium.org/viewvc/chrome/trunk/src/chrome/common/pref_names.cc?view=markup

It is useful for exemple to define the download directory

``` yaml
            selenium2:
                capabilities:
                    chrome:
                        switches:
                            ["--start-maximized"]
                        prefs:
                            download.prompt_for_download: false
                            download.default_directory: "/tmp"
```
