### PR TITLE
Add configuration parameters for Zombie.js driver

### DIFF
--- a/src/Behat/MinkExtension/Extension.php
+++ b/src/Behat/MinkExtension/Extension.php
@@ -207,6 +207,15 @@ class Extension implements ExtensionInterface
                         scalarNode('node_bin')->
                             defaultValue(isset($config['zombie']['node_bin']) ? $config['zombie']['node_bin'] : 'node')->
                         end()->
+                        scalarNode('server_path')->
+                            defaultValue(isset($config['zombie']['server_path']) ? $config['zombie']['server_path'] : null)->
+                        end()->
+                        scalarNode('threshold')->
+                            defaultValue(isset($config['zombie']['threshold']) ? $config['zombie']['threshold'] : 2000000)->
+                        end()->
+                        scalarNode('node_modules_path')->
+                            defaultValue(isset($config['zombie']['node_modules_path']) ? $config['zombie']['node_modules_path'] : '')->
+                        end()->
                     end()->
                 end()->
                 arrayNode('selenium')->

--- a/src/Behat/MinkExtension/services/sessions/zombie.xml
+++ b/src/Behat/MinkExtension/services/sessions/zombie.xml
@@ -12,6 +12,9 @@
         <parameter key="behat.mink.zombie.port">8124</parameter>
         <parameter key="behat.mink.zombie.auto_server">true</parameter>
         <parameter key="behat.mink.zombie.node_bin">node</parameter>
+        <parameter key="behat.mink.zombie.server_path">null</parameter>
+        <parameter key="behat.mink.zombie.threshold">2000000</parameter>
+        <parameter key="behat.mink.zombie.node_modules_path"></parameter>
 
     </parameters>
     <services>
@@ -37,6 +40,9 @@
             <argument>%behat.mink.zombie.host%</argument>
             <argument>%behat.mink.zombie.port%</argument>
             <argument>%behat.mink.zombie.node_bin%</argument>
+            <argument>%behat.mink.zombie.server_path%</argument>
+            <argument>%behat.mink.zombie.threshold%</argument>
+            <argument>%behat.mink.zombie.node_modules_path%</argument>
         </service>
 
     </services>


### PR DESCRIPTION
In the attached commit, I added three configuration parameters to the extension. These parameters are used to configure the used `ZombieServer`. 

In my current use case, I wanted to install zombie.js in my project's node_modules directory, not globally. To be able to use this zombie.js installation, I need to be able to configure the `node_modules_path` option of `ZombieServer`.
