### PR TITLE
master points to 1.0.x although 1.1.0 is out already

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.1.x-dev"
         }
     }
 }


### PR DESCRIPTION
Depending on your workflow even `1.2.x-dev` would do it.
