### PR TITLE
allow Symfony2.3 test to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,16 @@ language: php
 php: 
   - 5.3
   - 5.4
+  - 5.5
 
 env:
   - SYMFONY_VERSION='2.1.*'
   - SYMFONY_VERSION='2.2.*'
   - SYMFONY_VERSION='2.3.*@dev'
+
+matrix:
+  allow_failures:
+    - env: "SYMFONY_VERSION='2.3.*@dev'"
 
 branches:
   only:


### PR DESCRIPTION
Symfony2.3 is not stable yet, thus I don't think it should be responsible for a broken build. Another solution is to set `minimum:stability` to `dev`.
