### PR TITLE
Prevent Mink object from getting into serialized string.

### DIFF
--- a/src/Behat/MinkExtension/Listener/FailureShowListener.php
+++ b/src/Behat/MinkExtension/Listener/FailureShowListener.php
@@ -41,6 +41,13 @@ class FailureShowListener implements EventSubscriberInterface
     }
 
     /**
+     * Prevents Mink object from getting into serialized strings.
+     */
+    public function __sleep() {
+        return array();
+    }
+
+    /**
      * Returns an array of event names this subscriber wants to listen to.
      *
      * The array keys are event names and the value can be:

--- a/src/Behat/MinkExtension/Listener/SessionsListener.php
+++ b/src/Behat/MinkExtension/Listener/SessionsListener.php
@@ -41,6 +41,13 @@ class SessionsListener implements EventSubscriberInterface
     }
 
     /**
+     * Prevents Mink object from getting into serialized strings.
+     */
+    public function __sleep() {
+        return array();
+    }
+
+    /**
      * Returns an array of event names this subscriber wants to listen to.
      *
      * The array keys are event names and the value can be:


### PR DESCRIPTION
Here's the scenario where you get this problem:
1. You run the parallel test suite (either with gearman or with SG runner).
2. In your client class, you get the test results as a bunch of serialized event classes, which also have references to Mink, which makes it serialized as well.
3. Parallel workers end their Mink sessions just fine, but then unserialized Mink instance in client, which have references to the same sessions, throw exceptions during their __destruct() stage, because they can't stop sessions, which are already finished.

The solution is to prevent Mink getting to serialized string at first place.
