### PR TITLE
Fixed the configuration for Selenium2 capabilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "require": {
         "php":          ">=5.3.2",
         "behat/behat":  "~2.5.0",
-        "behat/mink":   ">=1.4.3,<1.6-dev"
+        "behat/mink":   ">=1.4.3,<1.6-dev",
+        "symfony/config": "~2.2"
     },
 
     "require-dev": {
@@ -24,11 +25,5 @@
 
     "autoload": {
         "psr-0": { "Behat\\MinkExtension": "src/" }
-    },
-
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.1.x-dev"
-        }
     }
 }

--- a/src/Behat/MinkExtension/Extension.php
+++ b/src/Behat/MinkExtension/Extension.php
@@ -271,6 +271,7 @@ class Extension implements ExtensionInterface
                             defaultValue(isset($config['selenium2']['browser']) ? $config['selenium2']['browser'] : '%behat.mink.browser_name%')->
                         end()->
                         arrayNode('capabilities')->
+                            normalizeKeys(false)->
                             children()->
                                 scalarNode('browserName')->
                                     defaultValue(isset($config['selenium2']['capabilities']['browserName']) ? $config['selenium2']['capabilities']['browserName'] : 'firefox')->


### PR DESCRIPTION
Some capabilities need to have a dash in their name to match the name expected by Selenium2 (which uses a mix of camel cased and dashed names).
This fix makes the MinkExtension incompatible with Symfony 2.0 and 2.1 but they already reached their end of maintenance anyway.
Closes #91
