### PR TITLE
Add support for max-duration capability option for saucelabs.

### DIFF
--- a/src/Behat/MinkExtension/Extension.php
+++ b/src/Behat/MinkExtension/Extension.php
@@ -397,6 +397,9 @@ class Extension implements ExtensionInterface
                                 scalarNode('deviceOrientation')->
                                     defaultValue(isset($config['saucelabs']['deviceOrientation']) ? $config['saucelabs']['deviceOrientation'] : null)->
                                 end()->
+                                scalarNode('max_duration')->
+                                    defaultValue(isset($config['saucelabs']['capabilities']['max-duration']) ? $config['saucelabs']['capabilities']['max-duration'] : '300')->
+                                end()->
                             end()->
                         end()->
                     end()->


### PR DESCRIPTION
The selenium2 config section allowed the definition of max-duration, but not saucelabs.  It's unclear why
max-duration was rewritten to max_duration before the behat.yml config was validated, but this change
works if you use max-duration in your behat.yml config, e.g:

```
default:
  extensions:
    SilverStripe\BehatExtension\MinkExtension:
      saucelabs:
        capabilities:
          max-duration: 900
```
