### PR TITLE
Add browserstack session type

### DIFF
--- a/src/Behat/MinkExtension/Extension.php
+++ b/src/Behat/MinkExtension/Extension.php
@@ -472,6 +472,9 @@ class Extension implements ExtensionInterface
                                 scalarNode('device')->
                                     defaultValue(isset($config['browserstack']['device']) ? $config['browserstack']['device'] : null)->
                                 end()->
+                                scalarNode('acceptSslCerts')->
+                                    defaultValue(isset($config['browserstack']['acceptSslCerts']) ? $config['browserstack']['acceptSslCerts'] : null)->
+                                end()->
                             end()->
                         end()->
                     end()->

--- a/src/Behat/MinkExtension/services/sessions/browserstack.xml
+++ b/src/Behat/MinkExtension/services/sessions/browserstack.xml
@@ -13,6 +13,7 @@
             <parameter key="platform" type="string">WINDOWS</parameter>
             <parameter key="selenium-version" type="string">2.31.0</parameter>
             <parameter key="max-duration">300</parameter>
+            <parameter key="acceptSslCerts">false</parameter>
         </parameter>
         <parameter key="behat.mink.browserstack.tunnel" type="string">false</parameter>
         <parameter key="behat.mink.browserstack.debug" type="string">false</parameter>


### PR DESCRIPTION
BrowserStack has some additional capabilities that are handy, such as os, os_version, browserstack-tunnel, browserstack-debug, etc. This adds a browserstack session type similar to the saucelabs session type.
