### PR TITLE
Adding configuration parameters for WebDriver timeout settings

### DIFF
--- a/src/Behat/MinkExtension/Extension.php
+++ b/src/Behat/MinkExtension/Extension.php
@@ -363,6 +363,12 @@ class Extension implements ExtensionInterface
                         scalarNode('wd_host')->
                             defaultValue(isset($config['selenium2']['wd_host']) ? $config['selenium2']['wd_host'] : 'http://localhost:4444/wd/hub')->
                         end()->
+                        arrayNode('timeouts')->
+                            children()->
+                                scalarNode('implicit')->end()->
+                                scalarNode('script')->end()->
+                            end()->
+                        end()->
                     end()->
                 end()->
                 arrayNode('saucelabs')->

--- a/src/Behat/MinkExtension/services/sessions/selenium2.xml
+++ b/src/Behat/MinkExtension/services/sessions/selenium2.xml
@@ -19,6 +19,7 @@
             <parameter key="selenium-version" type="string">2.31.0</parameter>
             <parameter key="max-duration">300</parameter>
         </parameter>
+        <parameter key="behat.mink.selenium2.timeouts" type="collection"/>
         <parameter key="behat.mink.selenium2.wd_host">http://localhost:4444/wd/hub</parameter>
 
     </parameters>
@@ -30,6 +31,9 @@
                     <argument>%behat.mink.selenium2.browser%</argument>
                     <argument>%behat.mink.selenium2.capabilities%</argument>
                     <argument>%behat.mink.selenium2.wd_host%</argument>
+                    <call method="setTimeouts">
+                        <argument>%behat.mink.selenium2.timeouts%</argument>
+                    </call>
                 </service>
             </argument>
             <argument type="service" id="behat.mink.selector.handler" />


### PR DESCRIPTION
Allows configuration in behat.yml

```
default:
  extensions:
  Behat\MinkExtension\Extension:
    base_url: http://en.wikipedia.org/
    selenium: 
      timeouts:
        implicit: 2000
```
