### PR TITLE
Simplified the travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,26 +7,17 @@ php:
   - 5.6
   - hhvm
 
-env:
-  - SYMFONY_VERSION='2.2.*'
-  - SYMFONY_VERSION='2.3.*'
-  - SYMFONY_VERSION='2.4.*'
-  - SYMFONY_VERSION='2.5.*@dev'
-
 matrix:
   allow_failures:
-    - env: "SYMFONY_VERSION='2.5.*@dev'"
     - php: hhvm
-  exclude:
-    - php: hhvm
-      env: SYMFONY_VERSION='2.2.*'
-    - php: hhvm
+  include:
+    - php: 5.5
       env: SYMFONY_VERSION='2.3.*'
-    - php: hhvm
+    - php: 5.5
       env: SYMFONY_VERSION='2.5.*@dev'
 
 before_script:
-  - composer require --no-update symfony/symfony=$SYMFONY_VERSION
+  - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
   - composer install --prefer-source
   - export PATH=./vendor/bin:$PATH
 


### PR DESCRIPTION
Given that the extension does not rely on lots of Symfony code by itself, the testing against multiple Symfony version is not done for all PHP versions anymore:
- Symfony `2.2.*` is not tested anymore (it is an EOL version)
- builds are using the dependencies resolved by Composer (latest stable components, so 2.4.\* at this time)
- extra jobs are added in the matrix to test the extension with Symfony `2.3.*` and `2.5.*@dev` on a single PHP version

This means that the matrix goes from 17 jobs to 7, making it much faster (we can only have 5 concurrent jobs for the whole github organization).

I also stop allowing failures on Symfony 2.5-dev as it is passing
