### PR TITLE
Added GhostDriver/Phantomjs support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ before_script:
   - curl http://getcomposer.org/installer | php
   - php composer.phar require --no-update symfony/symfony=$SYMFONY_VERSION
   - php composer.phar install --dev --prefer-source
+  - phantomjs -v
+  - phantomjs -w > /tmp/webdriver_output.txt &
   - export PATH=./vendor/bin:$PATH
 
 script: behat -fprogress
+
+after_failures:
+  - cat /tmp/webdriver_output.txt

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -2,4 +2,12 @@ default:
   extensions:
     Behat\MinkExtension\Extension:
       base_url: http://en.wikipedia.org/
+      javascript_session: phantomjs
       goutte:   ~
+      phantomjs:
+        # Run PhantomJS (`phantomjs -w &`) before to get the proxy
+        #settings:
+        #    { loadImages: false, userName: login, password: password }
+        custom_headers:
+          - { name: test_header, value: test_header }
+          - { name: xhaus-custom-header1, value: 42 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     },
 
     "require-dev": {
-        "behat/mink-goutte-driver": "~1.0"
+        "behat/mink-goutte-driver": "~1.0",
+        "adezandee/mink-ghost-driver": "dev-master"
     },
 
     "autoload": {

--- a/features/headers.feature
+++ b/features/headers.feature
@@ -1,0 +1,11 @@
+Feature: Custom Headers
+  PhantomJS should have custom header set when requesting a page
+
+  @javascript
+  Scenario: Go on http://myhttp.info/
+    Given I am on "http://www.xhaus.com/headers"
+    Then I should see "Your browser software transmitted the following HTTP headers"
+    And I should see "Test-Header" in the "table tbody" element
+    And I should see "test_header" in the "table tbody" element
+    And I should see "Xhaus-Custom-Header1" in the "table tbody" element
+    And I should see "42" in the "table tbody" element

--- a/src/Behat/MinkExtension/Extension.php
+++ b/src/Behat/MinkExtension/Extension.php
@@ -91,6 +91,15 @@ class Extension implements ExtensionInterface
 
             $loader->load('sessions/selenium2.xml');
         }
+        if (isset($config['phantomjs'])) {
+            if (!class_exists('Behat\\Mink\\Driver\\GhostDriver')) {
+                throw new \RuntimeException(
+                    'Install GhostDriver in order to activate phantomjs session.'
+                );
+            }
+
+            $loader->load('sessions/phantomjs.xml');
+        }
         if (isset($config['saucelabs'])) {
             if (!class_exists('Behat\\Mink\\Driver\\Selenium2Driver')) {
                 throw new \RuntimeException(
@@ -363,6 +372,39 @@ class Extension implements ExtensionInterface
                         end()->
                         scalarNode('wd_host')->
                             defaultValue(isset($config['selenium2']['wd_host']) ? $config['selenium2']['wd_host'] : 'http://localhost:4444/wd/hub')->
+                        end()->
+                    end()->
+                end()->
+                arrayNode('phantomjs')->
+                    children()->
+                        scalarNode('wd_host')->
+                            defaultValue(isset($config['phantomjs']['wd_host']) ? $config['phantomjs']['wd_host'] : 'http://localhost:8910/wd/hub')->
+                        end()->
+                        arrayNode('settings')->
+                            normalizeKeys(false)->
+                            children()->
+                                booleanNode('javascriptEnabled')->end()->
+                                booleanNode('loadImages')->end()->
+                                booleanNode('localToRemoteUrlAccessEnabled')->end()->
+                                scalarNode('userAgent')->
+                                    defaultValue(isset($config['phantomjs']['settings']['userAgent']) ? $config['phantomjs']['settings']['userAgent'] : 'Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) PhantomJS/1.9.7 Safari/534.34')->
+                                end()->
+                                scalarNode('userName')->end()->
+                                scalarNode('password')->end()->
+                                booleanNode('XSSAuditingEnabled')->end()->
+                                booleanNode('webSecurityEnabled')->end()->
+                                scalarNode('resourceTimeout')->
+                                    defaultValue(isset($config['phantomjs']['settings']['resourceTimeout']) ? $config['phantomjs']['settings']['resourceTimeout'] : "300")->
+                                end()->
+                            end()->
+                        end()->
+                        arrayNode('custom_headers')->
+                            prototype('array')
+                                ->children()
+                                    ->scalarNode('name')->isRequired()->end()
+                                    ->scalarNode('value')->isRequired()->end()
+                                ->end()
+                            ->end()->
                         end()->
                     end()->
                 end()->

--- a/src/Behat/MinkExtension/services/sessions/phantomjs.xml
+++ b/src/Behat/MinkExtension/services/sessions/phantomjs.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+
+        <parameter key="behat.mink.driver.phantomjs.class">Behat\Mink\Driver\GhostDriver</parameter>
+
+        <parameter key="behat.mink.phantomjs.wd_host">http://localhost:8910/wd/hub</parameter>
+        <parameter key="behat.mink.phantomjs.settings" type="collection">
+            <parameter key="javascriptEnabled">true</parameter>
+            <parameter key="loadImages">true</parameter>
+            <parameter key="localToRemoteUrlAccessEnabled">false</parameter>
+            <parameter key="userAgent" type="string">Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) PhantomJS/1.9.7 Safari/534.34</parameter>
+            <parameter key="userName" type="string" />
+            <parameter key="password" type="string" />
+            <parameter key="XSSAuditingEnabled">false</parameter>
+            <parameter key="webSecurityEnabled">true</parameter>
+            <parameter key="resourceTimeout" type="string">300</parameter>
+        </parameter>
+        <parameter key="behat.mink.phantomjs.custom_headers" type="collection" />
+
+    </parameters>
+    <services>
+
+        <service id="behat.mink.session.phantomjs" class="%behat.mink.session.class%">
+            <argument type="service">
+                <service class="%behat.mink.driver.phantomjs.class%">
+                    <argument>%behat.mink.phantomjs.wd_host%</argument>
+                    <argument>%behat.mink.phantomjs.settings%</argument>
+                    <argument>%behat.mink.phantomjs.custom_headers%</argument>
+                </service>
+            </argument>
+            <argument type="service" id="behat.mink.selector.handler" />
+            <tag name="behat.mink.session" alias="phantomjs" />
+        </service>
+
+    </services>
+</container>


### PR DESCRIPTION
This add Phantomjs direct support (instead of using a workaround with selenium2 confs).
On top of that, you can now set Custom Headers and Basic auth throught behat.yml (and other options available with GhostDriver).

I created the MinkGhostDriver implementation from Selenium2 driver, available here (and on Packagist) : https://github.com/Adezandee/MinkGhostDriver
