### PR TITLE
Added the possibility to define the default session per suite

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -144,18 +144,18 @@ Sessions
 You can register as many Mink session as you want. For each session, you
 will need to choose the driver you want to use.
 
-    .. code-block:: yaml
+.. code-block:: yaml
 
-        default:
-            extensions:
-                Behat\MinkExtension\Extension:
-                    sessions:
-                        first_session:
-                            selenium2: ~
-                        second_session:
-                            goutte: ~
-                        third_session:
-                            selenium2: ~
+    default:
+        extensions:
+            Behat\MinkExtension\Extension:
+                sessions:
+                    first_session:
+                        selenium2: ~
+                    second_session:
+                        goutte: ~
+                    third_session:
+                        selenium2: ~
 
 MinkExtension will set the default Mink session for each scenario based on
 the configuration settings ``default_session`` and ``javascript_session``
@@ -164,6 +164,17 @@ and on scenario tags:
 * A scenario tagged with ``@mink:foo`` will use ``foo`` as default session;
 * A scenario tagged with ``@javascript`` will use the javascript session as default session;
 * Other scenarios will use the default session.
+
+The default session and the default javascript session can also be configured for
+each suite:
+
+.. code-block:: yaml
+
+    default:
+        suites:
+            first:
+                mink_session: foo
+                mink_javascript_session: sahi
 
 If it is not configured explicitly, the javascript session is set to the first
 session using a javascript driver in the order of the configuration (it would

--- a/spec/Behat/MinkExtension/Listener/SessionsListenerSpec.php
+++ b/spec/Behat/MinkExtension/Listener/SessionsListenerSpec.php
@@ -7,16 +7,22 @@ use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioNode;
 use Behat\Mink\Mink;
 use Behat\Testwork\ServiceContainer\Exception\ProcessingException;
+use Behat\Testwork\Suite\Exception\SuiteConfigurationException;
+use Behat\Testwork\Suite\Suite;
 use PhpSpec\ObjectBehavior;
 
 class SessionsListenerSpec extends ObjectBehavior
 {
-    function let(Mink $mink, ScenarioTested $event, FeatureNode $feature, ScenarioNode $scenario)
+    function let(Mink $mink, ScenarioTested $event, FeatureNode $feature, ScenarioNode $scenario, Suite $suite)
     {
-        $this->beConstructedWith($mink, 'goutte', 'selenium2');
+        $this->beConstructedWith($mink, 'goutte', 'selenium2', array('selenium2', 'sahi'));
 
+        $event->getSuite()->willReturn($suite);
         $event->getFeature()->willReturn($feature);
         $event->getScenario()->willReturn($scenario);
+
+        $suite->hasSetting('mink_session')->willReturn(false);
+        $suite->getName()->willReturn('default');
 
         $feature->hasTag('insulated')->willReturn(false);
         $feature->getTags()->willReturn(array());
@@ -37,8 +43,29 @@ class SessionsListenerSpec extends ObjectBehavior
         $this->prepareDefaultMinkSession($event);
     }
 
-    function it_switches_to_the_javascript_session_for_tagged_scenarios($event, $mink, $scenario)
+    function it_supports_changing_the_default_session_per_suite($event, $mink, $suite)
     {
+        $suite->hasSetting('mink_session')->willReturn(true);
+        $suite->getSetting('mink_session')->willReturn('test');
+
+        $mink->resetSessions()->shouldBeCalled();
+        $mink->setDefaultSessionName('test')->shouldBeCalled();
+
+        $this->prepareDefaultMinkSession($event);
+    }
+
+    function it_fails_for_non_string_default_suite_session($event, $suite)
+    {
+        $suite->hasSetting('mink_session')->willReturn(true);
+        $suite->getSetting('mink_session')->willReturn(array());
+
+        $this->shouldThrow(new SuiteConfigurationException('`mink_session` setting of the "default" suite is expected to be a string, array given.', 'default'))
+            ->duringPrepareDefaultMinkSession($event);
+    }
+
+    function it_switches_to_the_javascript_session_for_tagged_scenarios($event, $mink, $scenario, $suite)
+    {
+        $suite->hasSetting('mink_javascript_session')->willReturn(false);
         $scenario->getTags()->willReturn(array('javascript'));
         $mink->resetSessions()->shouldBeCalled();
         $mink->setDefaultSessionName('selenium2')->shouldBeCalled();
@@ -46,8 +73,9 @@ class SessionsListenerSpec extends ObjectBehavior
         $this->prepareDefaultMinkSession($event);
     }
 
-    function it_switches_to_the_javascript_session_for_tagged_features($event, $mink, $feature)
+    function it_switches_to_the_javascript_session_for_tagged_features($event, $mink, $feature, $suite)
     {
+        $suite->hasSetting('mink_javascript_session')->willReturn(false);
         $feature->getTags()->willReturn(array('javascript'));
         $mink->resetSessions()->shouldBeCalled();
         $mink->setDefaultSessionName('selenium2')->shouldBeCalled();
@@ -55,8 +83,43 @@ class SessionsListenerSpec extends ObjectBehavior
         $this->prepareDefaultMinkSession($event);
     }
 
-    function it_fails_when_the_javascript_session_is_used_but_not_defined($event, $mink, $feature)
+    function it_supports_changing_the_default_javascript_session_per_suite($event, $mink, $scenario, $suite)
     {
+        $suite->hasSetting('mink_javascript_session')->willReturn(true);
+        $suite->getSetting('mink_javascript_session')->willReturn('sahi');
+
+        $scenario->getTags()->willReturn(array('javascript'));
+        $mink->resetSessions()->shouldBeCalled();
+        $mink->setDefaultSessionName('sahi')->shouldBeCalled();
+
+        $this->prepareDefaultMinkSession($event);
+    }
+
+    function it_fails_for_non_string_javascript_suite_session($event, $scenario, $suite)
+    {
+        $suite->hasSetting('mink_javascript_session')->willReturn(true);
+        $suite->getSetting('mink_javascript_session')->willReturn(array());
+
+        $scenario->getTags()->willReturn(array('javascript'));
+
+        $this->shouldThrow(new SuiteConfigurationException('`mink_javascript_session` setting of the "default" suite is expected to be a string, array given.', 'default'))
+            ->duringPrepareDefaultMinkSession($event);
+    }
+
+    function it_fails_for_invalid_javascript_suite_session($event, $scenario, $suite)
+    {
+        $suite->hasSetting('mink_javascript_session')->willReturn(true);
+        $suite->getSetting('mink_javascript_session')->willReturn('test');
+
+        $scenario->getTags()->willReturn(array('javascript'));
+
+        $this->shouldThrow(new SuiteConfigurationException('`mink_javascript_session` setting of the "default" suite is not a javascript session. test given but expected one of selenium2, sahi.', 'default'))
+            ->duringPrepareDefaultMinkSession($event);
+    }
+
+    function it_fails_when_the_javascript_session_is_used_but_not_defined($event, $mink, $feature, $suite)
+    {
+        $suite->hasSetting('mink_javascript_session')->willReturn(false);
         $this->beConstructedWith($mink, 'goutte', null);
         $feature->getTags()->willReturn(array('javascript'));
 
@@ -73,8 +136,9 @@ class SessionsListenerSpec extends ObjectBehavior
         $this->prepareDefaultMinkSession($event);
     }
 
-    function it_prefers_the_scenario_over_the_feature($event, $mink, $scenario, $feature)
+    function it_prefers_the_scenario_over_the_feature($event, $mink, $scenario, $feature, $suite)
     {
+        $suite->hasSetting('mink_javascript_session')->willReturn(false);
         $scenario->getTags()->willReturn(array('mink:test'));
         $feature->getTags()->willReturn(array('javascript'));
         $mink->resetSessions()->shouldBeCalled();

--- a/src/Behat/MinkExtension/Extension.php
+++ b/src/Behat/MinkExtension/Extension.php
@@ -255,6 +255,7 @@ class Extension implements ExtensionInterface
 
         $container->setParameter('mink.default_session', $defaultSession);
         $container->setParameter('mink.javascript_session', $javascriptSession);
+        $container->setParameter('mink.available_javascript_sessions', $javascriptSessions);
     }
 
     private function loadSessionsListener(ContainerBuilder $container)
@@ -263,6 +264,7 @@ class Extension implements ExtensionInterface
             new Reference(self::MINK_ID),
             '%mink.default_session%',
             '%mink.javascript_session%',
+            '%mink.available_javascript_sessions%',
         ));
         $definition->addTag(EventDispatcherExtension::SUBSCRIBER_TAG, array('priority' => 0));
         $container->setDefinition('mink.listener.sessions', $definition);


### PR DESCRIPTION
Here is the feature I announced at the SymfonyLive.

This feature means it is now possible to run the same tests against different browsers in a single behat run: define several suites with the same features and the same contexts but changing the default session.
