### PR TITLE
Renamed the extension class to follow the Behat shortcut convention

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -4,7 +4,7 @@ default:
       path: %paths.base%/features
       contexts: [Behat\MinkExtension\Context\MinkContext]
   extensions:
-    Behat\MinkExtension\Extension:
+    Behat\MinkExtension:
       base_url: http://en.wikipedia.org/
       sessions:
         default:

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "behat-extension",
     "description": "Mink extension for Behat",
     "keywords": ["web", "test", "browser", "gui"],
-    "homepage": "http://mink.behat.org",
+    "homepage": "http://extensions.behat.org/mink",
     "license": "MIT",
     "authors": [
         {
@@ -18,7 +18,7 @@
 
     "require": {
         "php":          ">=5.3.2",
-        "behat/behat":  "~3.0",
+        "behat/behat":  "~3.0,>=3.0.5",
         "behat/mink":   "~1.5",
         "symfony/config": "~2.2"
     },
@@ -31,7 +31,6 @@
     "autoload": {
         "psr-0": { "Behat\\MinkExtension": "src/" }
     },
-    
 
     "extra": {
         "branch-alias": {

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -58,7 +58,7 @@ The easiest way to keep your suite updated is to use `Composer <http://getcompos
         default:
           # ...
           extensions:
-            Behat\MinkExtension\Extension:
+            Behat\MinkExtension:
               base_url:  'http://example.com'
               sessions:
                 default:
@@ -148,7 +148,7 @@ will need to choose the driver you want to use.
 
     default:
         extensions:
-            Behat\MinkExtension\Extension:
+            Behat\MinkExtension:
                 sessions:
                     first_session:
                         selenium2: ~
@@ -197,7 +197,7 @@ with support for 6 drivers out of the box:
 
         default:
             extensions:
-                Behat\MinkExtension\Extension:
+                Behat\MinkExtension:
                     sessions:
                         my_session:
                             goutte: ~
@@ -211,7 +211,7 @@ the following parameters to avoid the validation error triggered by Guzzle :
 
     default:
       extensions:
-        Behat\MinkExtension\Extension:
+        Behat\MinkExtension:
           sessions:
             my_session:
               goutte:
@@ -225,7 +225,7 @@ the following parameters to avoid the validation error triggered by Guzzle :
 
         default:
             extensions:
-                Behat\MinkExtension\Extension:
+                Behat\MinkExtension:
                     sessions:
                         my_session:
                             selenium2: ~
@@ -238,7 +238,7 @@ the following parameters to avoid the validation error triggered by Guzzle :
 
         default:
             extensions:
-                Behat\MinkExtension\Extension:
+                Behat\MinkExtension:
                     sessions:
                         my_session:
                             sauce_labs: ~
@@ -251,7 +251,7 @@ the following parameters to avoid the validation error triggered by Guzzle :
 
         default:
             extensions:
-                Behat\MinkExtension\Extension:
+                Behat\MinkExtension:
                     sessions:
                         my_session:
                             browser_stack: ~
@@ -263,7 +263,7 @@ the following parameters to avoid the validation error triggered by Guzzle :
 
         default:
             extensions:
-                Behat\MinkExtension\Extension:
+                Behat\MinkExtension:
                     sessions:
                         my_session:
                             selenium: ~
@@ -287,7 +287,7 @@ the following parameters to avoid the validation error triggered by Guzzle :
 
         default:
             extensions:
-                Behat\MinkExtension\Extension:
+                Behat\MinkExtension:
                     sessions:
                         default:
                             zombie: ~

--- a/init.php
+++ b/init.php
@@ -16,4 +16,4 @@ spl_autoload_register(function($class) {
     }
 }, true, false);
 
-return new Behat\MinkExtension\Extension;
+return new Behat\MinkExtension\ServiceContainer\MinkExtension;

--- a/spec/Behat/MinkExtension/ServiceContainer/MinkExtensionSpec.php
+++ b/spec/Behat/MinkExtension/ServiceContainer/MinkExtensionSpec.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace spec\Behat\MinkExtension;
+namespace spec\Behat\MinkExtension\ServiceContainer;
 
 use PhpSpec\ObjectBehavior;
 
-class ExtensionSpec extends ObjectBehavior
+class MinkExtensionSpec extends ObjectBehavior
 {
     function it_is_a_testwork_extension()
     {

--- a/src/Behat/MinkExtension/ServiceContainer/MinkExtension.php
+++ b/src/Behat/MinkExtension/ServiceContainer/MinkExtension.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Behat\MinkExtension;
+namespace Behat\MinkExtension\ServiceContainer;
 
 use Behat\Behat\Context\ServiceContainer\ContextExtension;
 use Behat\MinkExtension\ServiceContainer\Driver\BrowserStackFactory;
@@ -33,8 +33,9 @@ use Symfony\Component\DependencyInjection\Reference;
  * Mink extension for Behat class.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ * @author Christophe Coevoet <stof@notk.org>
  */
-class Extension implements ExtensionInterface
+class MinkExtension implements ExtensionInterface
 {
     const MINK_ID = 'mink';
     const SELECTORS_HANDLER_ID = 'mink.selectors_handler';


### PR DESCRIPTION
This adds another BC break in the process of going from Behat 2.x to Behat 3.x (and it breaks BC for people who already did this process using the dev version of the extension), but it is much nicer IMO.
