### PR TITLE
Making regex'es not to match the quotes

### DIFF
--- a/src/Behat/MinkExtension/Context/MinkContext.php
+++ b/src/Behat/MinkExtension/Context/MinkContext.php
@@ -209,7 +209,7 @@ class MinkContext extends RawMinkContext implements TranslatableContext
     /**
      * Checks, that current page PATH matches regular expression.
      *
-     * @Then /^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/
+     * @Then /^the (?i)url(?-i) should match "(?P<pattern>(?:[^"]|\\")*)"$/
      */
     public function assertUrlRegExp($pattern)
     {
@@ -259,7 +259,7 @@ class MinkContext extends RawMinkContext implements TranslatableContext
     /**
      * Checks, that page contains text matching specified pattern.
      *
-     * @Then /^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/
+     * @Then /^(?:|I )should see text matching "(?P<pattern>(?:[^"]|\\")*)"$/
      */
     public function assertPageMatchesText($pattern)
     {
@@ -269,7 +269,7 @@ class MinkContext extends RawMinkContext implements TranslatableContext
     /**
      * Checks, that page doesn't contain text matching specified pattern.
      *
-     * @Then /^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/
+     * @Then /^(?:|I )should not see text matching "(?P<pattern>(?:[^"]|\\")*)"$/
      */
     public function assertPageNotMatchesText($pattern)
     {


### PR DESCRIPTION
Some regex'es match the quotes along with the actual value, making it impossible to use the definitions, e.g., #152.
