### PR TITLE
Review "to be" translation on the-checkbox-should-be-checked and the-checkbox-should-not-be-checked

### DIFF
--- a/i18n/pt.xliff
+++ b/i18n/pt.xliff
@@ -104,11 +104,11 @@
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
             <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
-            <target><![CDATA[/^o checkbox "(?P<checkbox>(?:[^"]|\\")*)" deve ser marcado$/]]></target>
+            <target><![CDATA[/^o checkbox "(?P<checkbox>(?:[^"]|\\")*)" deve (?:ser|estar) marcado$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-not-be-checked">
             <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should not be checked$/]]></source>
-            <target><![CDATA[/^o checkbox "(?P<checkbox>(?:[^"]|\\")*)" não deve ser marcado$/]]></target>
+            <target><![CDATA[/^o checkbox "(?P<checkbox>(?:[^"]|\\")*)" não deve (?:ser|estar) marcado$/]]></target>
         </trans-unit>
         <trans-unit id="i-should-be-on-page">
             <source><![CDATA[/^(?:|I )should be on "(?P<page>[^"]+)"$/]]></source>


### PR DESCRIPTION
"To Be" verb can be translated to "ser" or "estar" verbs in portuguese, depending on the context. In this case, verifying the state of something (checkboxes), it is better translating it to "estar". I've used the conditional to not break old features.