### PR TITLE
Allow more sophisticated base_url

### DIFF
--- a/src/Behat/MinkExtension/Context/RawMinkContext.php
+++ b/src/Behat/MinkExtension/Context/RawMinkContext.php
@@ -134,9 +134,22 @@ class RawMinkContext implements MinkAwareContext
      */
     public function locatePath($path)
     {
-        $startUrl = rtrim($this->getMinkParameter('base_url'), '/') . '/';
+        if (0 === strpos($path, 'http')) {
+            return $path;
+        }
 
-        return 0 !== strpos($path, 'http') ? $startUrl . ltrim($path, '/') : $path;
+        $parts = parse_url($this->getMinkParameter('base_url'));
+        $path = ltrim($path, '/');
+        $parts['path'] = empty($parts['path']) ? '/' : rtrim($parts['path'], '/') . '/';
+
+        $url = empty($parts['scheme']) ? 'http' : $parts['scheme'];
+        $url .= '://';
+        $url .= empty($parts['user']) ? '' : ($parts['user'] . (empty($parts['pass']) ? '' : ':' . $parts['pass']) . '@');
+        $url .= $parts['host'] . $parts['path'] . $path;
+        $url .= empty($parts['query']) ? '' : '?' . $parts['query'];
+        $url .= empty($parts['fragment']) ? '' : '#' . $parts['fragment'];
+
+        return $url;
     }
 
     /**


### PR DESCRIPTION
If the base_url contains a query and/or a fragment, then the locatePath() delivers incorrect results. Example:

```
base_url: http://www.example.com/subsite/?language=de&abc=1#anchor
path to visit: /user

Result wrong: http://www.example.com/subsite/?language=de&abc=1#anchor/user
Expected result: http://www.example.com/subsite/user?language=de&abc=1#anchor
```

This code is going to deal with all possible cases.
