### PR TITLE
Throw exception if mink has not been set in context

### DIFF
--- a/src/Behat/MinkExtension/Context/RawMinkContext.php
+++ b/src/Behat/MinkExtension/Context/RawMinkContext.php
@@ -42,6 +42,13 @@ class RawMinkContext implements MinkAwareContext
      */
     public function getMink()
     {
+        if (null === $this->mink) {
+            throw new \RuntimeException(
+                'Mink instance has not been set on Mink context class. ' . 
+                'Have you enabled the Mink Extension?'
+            );
+        }
+
         return $this->mink;
     }
 


### PR DESCRIPTION
Throw an exception if the context has not set rather than:

````
PHP Fatal error:  Call to a member function getSession() on null in /home/daniel/www/sulu-cmf/sulu-standard/vendor/behat/mink-extension/src/Behat/MinkExtension/Context/RawMinkContext.php on line 102
````

This happens when mink has not been configured in `behat.yml`.