### PR TITLE
Remove default config values

### DIFF
--- a/src/Behat/MinkExtension/ServiceContainer/Driver/BrowserStackFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/BrowserStackFactory.php
@@ -62,6 +62,11 @@ class BrowserStackFactory extends Selenium2Factory
                 ->scalarNode('device')->end()
                 ->booleanNode('browserstack-debug')->end()
                 ->booleanNode('browserstack-tunnel')->end()
+
+                // Erase default values from parent Selenium2Factory
+                ->scalarNode('browserName')->end()
+                ->scalarNode('browserVersion')->end()
+                ->scalarNode('version')->end()
             ->end()
         ;
 


### PR DESCRIPTION
Remove default config values, defined in Selenium2Factory parent.
Don's send useless parameters (browserVersion) rejected by Browserstack when use device parameter.