### PR TITLE
[Easy-Pick] Fixed Selenium2 ignoreZoomSetting configuration in Selenium2Factory

### DIFF
--- a/src/Behat/MinkExtension/ServiceContainer/Driver/Selenium2Factory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/Selenium2Factory.php
@@ -98,7 +98,7 @@ class Selenium2Factory implements DriverFactory
                 ->scalarNode('platform')->defaultValue('ANY')->end()
                 ->scalarNode('browserVersion')->defaultValue('9')->end()
                 ->scalarNode('browser')->defaultValue('firefox')->end()
-                ->scalarNode('ignoreZoomSetting')->defaultValue('false')->end()
+                ->booleanNode('ignoreZoomSetting')->defaultFalse()->end()
                 ->scalarNode('name')->defaultValue('Behat feature suite')->end()
                 ->scalarNode('deviceOrientation')->defaultValue('portrait')->end()
                 ->scalarNode('deviceType')->defaultValue('tablet')->end()


### PR DESCRIPTION
This PR also fixes a bug in the latest version of IEDriverServer + Selenium2, which triggers a segmentation fault if the value given for ignoreZoomSetting is a string and not a boolean (which is the case currently).
A simple check for this is to try launching Behat + mink + Selenium2 with Selenium2 + IEDriverServer, with the following defaults:

```yml
default:
  suites:
    default:
      contexts:
        - Behat\MinkExtension\Context\MinkContext
  extensions:
    Behat\MinkExtension:
      javascript_session: default
        sessions:
          default:
            selenium2:
              browser: "internet explorer"
```

Adding the capabilities with ignoreZoomSetting set to true or false also fixes the issue, but not at the source of the problem.