### PR TITLE
Update docs example for disable SSL certificate verification in Guzzle

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -205,18 +205,33 @@ with support for 6 drivers out of the box:
   .. Tips : HTTPS and self-signed certificate
   In case you use Behat/Mink/Goutte to test your application, and want to test an
   application secured with HTTPS, but with a self-signed certificate, you can use
-  the following parameters to avoid the validation error triggered by Guzzle :
+  the following parameters to avoid the validation error triggered by Guzzle:
 
-    .. code-block:: yaml
+  * For ``Guzzle 4`` or later:
+  
+      .. code-block:: yaml
 
-        default:
-            extensions:
-                Behat\MinkExtension:
-                    sessions:
-                        my_session:
-                            goutte:
-                                guzzle_parameters:
-                                    verify: false
+          default:
+              extensions:
+                  Behat\MinkExtension:
+                      sessions:
+                          my_session:
+                              goutte:
+                                  guzzle_parameters:
+                                      verify: false
+  
+  * For ``Guzzle 3`` or earlier:
+  
+      .. code-block:: yaml
+
+          default:
+              extensions:
+                  Behat\MinkExtension:
+                      sessions:
+                          my_session:
+                              goutte:
+                                  guzzle_parameters:
+                                      ssl.certificate_authority: false
 
 * ``Selenium2Driver`` - javascript driver. In order to use it, modify your
   ``behat.yml`` profile:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -216,7 +216,7 @@ the following parameters to avoid the validation error triggered by Guzzle :
             my_session:
               goutte:
                 guzzle_parameters:
-                  ssl.certificate_authority: false
+                  verify: false
 
 * ``Selenium2Driver`` - javascript driver. In order to use it, modify your
   ``behat.yml`` profile:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -202,21 +202,21 @@ with support for 6 drivers out of the box:
                         my_session:
                             goutte: ~
 
-.. Tips : HTTPS and self-signed certificate
-In case you use Behat/Mink/Goutte to test your application, and want to test an
-application secured with HTTPS, but with a self-signed certificate, you can use
-the following parameters to avoid the validation error triggered by Guzzle :
+  .. Tips : HTTPS and self-signed certificate
+  In case you use Behat/Mink/Goutte to test your application, and want to test an
+  application secured with HTTPS, but with a self-signed certificate, you can use
+  the following parameters to avoid the validation error triggered by Guzzle :
 
-  .. code-block:: yaml
+    .. code-block:: yaml
 
-    default:
-      extensions:
-        Behat\MinkExtension:
-          sessions:
-            my_session:
-              goutte:
-                guzzle_parameters:
-                  verify: false
+        default:
+            extensions:
+                Behat\MinkExtension:
+                    sessions:
+                        my_session:
+                            goutte:
+                                guzzle_parameters:
+                                    verify: false
 
 * ``Selenium2Driver`` - javascript driver. In order to use it, modify your
   ``behat.yml`` profile:


### PR DESCRIPTION
Update docs example for disable SSL certificate verification behaviour in Guzzle 5 using the **verify** option documented [here](http://docs.guzzlephp.org/en/latest/clients.html?highlight=verify#verify).

Also fix inconsistencies in markdown and code indentation in the Goutte driver examples