### PR TITLE
Add emulator option to BrowserStack capabilities.

### DIFF
--- a/src/Behat/MinkExtension/ServiceContainer/Driver/BrowserStackFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/BrowserStackFactory.php
@@ -61,6 +61,7 @@ class BrowserStackFactory extends Selenium2Factory
                 ->scalarNode('device')->end()
                 ->booleanNode('browserstack-debug')->end()
                 ->booleanNode('browserstack-tunnel')->end()
+                ->booleanNode('emulator')->end()
             ->end()
         ;
 


### PR DESCRIPTION
Hi,
I would like to add the emulator option to BrowserStack capabilities.

This option allows you to run iOS devices via. an Emulator instead of real devices which is sometimes necessary as they are using Appium to run tests on real devices, which fails for example if you try to delete cookies.
This option is currently not documented on BrowserStack but I got the hint of their support to use this option.

thank you 
