### PR TITLE
add findOrRetry method

### DIFF
--- a/src/Behat/MinkExtension/Context/MinkContext.php
+++ b/src/Behat/MinkExtension/Context/MinkContext.php
@@ -12,6 +12,7 @@ namespace Behat\MinkExtension\Context;
 
 use Behat\Behat\Context\TranslatableContext;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Element\Element;
 
 /**
  * Mink context for Behat BDD tool.
@@ -238,22 +239,34 @@ class MinkContext extends RawMinkContext implements TranslatableContext
 
     /**
      * Checks, that page contains specified text.
+     * @param string  $text    the text to check
+     * @param integer $timeout in milliseconds
      *
      * @Then /^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/
      */
-    public function assertPageContainsText($text)
+    public function assertPageContainsText($text, $timeout = 10000)
     {
-        $this->assertSession()->pageTextContains($this->fixStepArgument($text));
+        $element = $this->findOrRetry($this->getSession()->getPage(), $text, $timeout);
+        if (!$element) {
+            $message = sprintf('The text "%s" was not found anywhere in the text of the current page.', $text);
+            throw new \Behat\Mink\Exception\ResponseTextException($message, $this->getSession());
+        }
     }
 
     /**
      * Checks, that page doesn't contain specified text.
+     * @param string  $text    the text to check
+     * @param integer $timeout in milliseconds
      *
      * @Then /^(?:|I )should not see "(?P<text>(?:[^"]|\\")*)"$/
      */
-    public function assertPageNotContainsText($text)
+    public function assertPageNotContainsText($text, $timeout = 10000)
     {
-        $this->assertSession()->pageTextNotContains($this->fixStepArgument($text));
+        $element = $this->findOrRetry($this->getSession()->getPage(), $text, $timeout);
+        if ($element && $element->isVisible()) {
+            $message = sprintf('The text "%s" was found in the text of the current page although it should not.', $text);
+            throw new \Behat\Mink\Exception\ResponseTextException($message, $this->getSession());
+        }
     }
 
     /**
@@ -298,12 +311,32 @@ class MinkContext extends RawMinkContext implements TranslatableContext
 
     /**
      * Checks, that element with specified CSS contains specified text.
+     * @param string  $element the element where search
+     * @param string  $text    the text to check
+     * @param integer $timeout in milliseconds
      *
      * @Then /^(?:|I )should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]*)" element$/
      */
-    public function assertElementContainsText($element, $text)
+    public function assertElementContainsText($element, $text, $timeout = 10000)
     {
-        $this->assertSession()->elementTextContains('css', $element, $this->fixStepArgument($text));
+        if ($timeout <= 0) {
+            $message = sprintf('The element "%s" was not found in the page.', $element);
+            throw new \Behat\Mink\Exception\ResponseTextException($message, $this->getSession());
+        }
+        $selectorType = 'css';
+
+        $node = $this->getSession()->getPage()->find($selectorType, $element);
+
+        if (is_object($node)) {
+            $item = $this->findOrRetry($node, $text);
+            if (!$item) {
+                $this->assertElementContainsText($element, $text, 0);
+            }
+        } else {
+            $this->getSession()->wait(100);
+
+            return $this->assertElementContainsText($element, $text, $timeout - 100);
+        }
     }
 
     /**
@@ -482,5 +515,33 @@ class MinkContext extends RawMinkContext implements TranslatableContext
     protected function fixStepArgument($argument)
     {
         return str_replace('\\"', '"', $argument);
+    }
+
+    /**
+     * Try to find value in element and retry for a given time
+     * @param Element $element
+     * @param string  $value
+     * @param integer $timeout
+     */
+    protected function findOrRetry(Element $element, $value, $timeout = 10000)
+    {
+        if ($timeout <= 0) {
+            return false;
+        }
+
+        // Hack to do an insensitive case search
+        $alphabetLower = '"'.implode('', range('a', 'z')).'"';
+        $alphabetUpper = '"'.implode('', range('A', 'Z')).'"';
+
+        $item = $element->find('xpath', '/descendant-or-self::*[contains(translate(text(), '.$alphabetUpper.', '.$alphabetLower.'), translate("'.$value.'", '.$alphabetUpper.', '.$alphabetLower.'))]');
+
+        if ($item) {
+            return $item;
+        } else {
+            $this->getSession()->wait(100);
+
+            return $this->findOrRetry($element, $value, $timeout - 100);
+        }
+
     }
 }


### PR DESCRIPTION
This method allows to be more flexible in some cases :

Page contains "content"
```
    Then we should see "Content"
```

Page doesn't contains "Content"
```
    Then we should not see "Content"
```

This is a solution for : 
- hidden content becomes visible after animation
- content appears in ajax