### PR TITLE
Fixing bad translation for the-checkbox-should-be-checked in Spanish

### DIFF
--- a/i18n/es.xliff
+++ b/i18n/es.xliff
@@ -104,7 +104,7 @@
         </trans-unit>
         <trans-unit id="the-checkbox-should-be-checked">
             <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should be checked$/]]></source>
-            <target><![CDATA[/^la casilla de selección "(?P<checkbox>[^"]*) debe estar marcada" $/]]></target>
+            <target><![CDATA[/^la casilla de selección "(?P<checkbox>[^"]*)" debe estar marcada$/]]></target>
         </trans-unit>
         <trans-unit id="the-checkbox-should-not-be-checked">
             <source><![CDATA[/^the "(?P<checkbox>(?:[^"]|\\")*)" checkbox should not be checked$/]]></source>


### PR DESCRIPTION
The translation didn't work as expected because the expression wasn't correct.