### PR TITLE
fixed guzzle parameter passing

### DIFF
--- a/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php
@@ -90,7 +90,7 @@ class GoutteFactory implements DriverFactory
         $parameters['allow_redirects'] = false;
         $parameters['cookies'] = true;
 
-        return new Definition('GuzzleHttp\Client', array(array('defaults' => $parameters)));
+        return new Definition('GuzzleHttp\Client', array($parameters));
 
     }
 


### PR DESCRIPTION
Guzzle does not expect 'default' array to be passed to the constructor. If passed as a default key, guzzle will not updates it's defaults.