### PR TITLE
Add Marionette capability for Selenium2Driver

### DIFF
--- a/src/Behat/MinkExtension/ServiceContainer/Driver/Selenium2Factory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/Selenium2Factory.php
@@ -98,6 +98,7 @@ class Selenium2Factory implements DriverFactory
                 ->scalarNode('platform')->end()
                 ->scalarNode('browserVersion')->end()
                 ->scalarNode('browser')->defaultValue('firefox')->end()
+                ->booleanNode('marionette')->defaultFalse()->end()
                 ->booleanNode('ignoreZoomSetting')->defaultFalse()->end()
                 ->scalarNode('name')->defaultValue('Behat feature suite')->end()
                 ->scalarNode('deviceOrientation')->end()


### PR DESCRIPTION
Marionette is this new thing to interact with Firefox browsers.

I haven't heard of it, until today. According to [this Mozilla help page](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver) you'll have to tell your Selenium driver to request `marionette` capability, until Marionette will be the default one.

This PR adds the capability, so I can add the following to my `behat.yml` to use Marionette with (at least Selenium 2.53). Without it, MinkExtension complains that it doesn't know the option.

```yaml
default:
  extensions:
    Behat\MinkExtension:
      sessions:
        default:
          selenium2:
            capabilities: { "marionette": true }
```