### PR TITLE
Screenshot filename has invalid characters

### DIFF
--- a/src/Behat/MinkExtension/Context/RawMinkContext.php
+++ b/src/Behat/MinkExtension/Context/RawMinkContext.php
@@ -158,7 +158,7 @@ class RawMinkContext implements MinkAwareContext
     {
         // Under Cygwin, uniqid with more_entropy must be set to true.
         // No effect in other environments.
-        $filename = $filename ?: sprintf('%s_%s_%s.%s', $this->getMinkParameter('browser_name'), date('c'), uniqid('', true), 'png');
+        $filename = $filename ?: sprintf('%s_%s_%s.%s', $this->getMinkParameter('browser_name'), date('Y-m-d_H.i.s'), uniqid('', true), 'png');
         $filepath = $filepath ?: (ini_get('upload_tmp_dir') ? ini_get('upload_tmp_dir') : sys_get_temp_dir());
         file_put_contents($filepath . '/' . $filename, $this->getSession()->getScreenshot());
     }


### PR DESCRIPTION
The screenshot filename "firefox_2016-07-12T15:19:21+00:00.578f8b3deeff62.22313382.png" contains invalid characters on Windows. This PR changes it to "firefox_2016-07-20_16.31.25_578f8b3deeff62.22313382.png"