### PR TITLE
Adding an exception when the file you are trying to attach is not found

### DIFF
--- a/src/Behat/MinkExtension/Context/MinkContext.php
+++ b/src/Behat/MinkExtension/Context/MinkContext.php
@@ -213,6 +213,9 @@ class MinkContext extends RawMinkContext implements TranslatableContext
             if (is_file($fullPath)) {
                 $path = $fullPath;
             }
+            else {
+                throw new \Exception(sprintf('"The file "%s" was not found in "%s" folder.', $path, $this->getMinkParameter('files_path')));
+            }
         }
 
         $this->getSession()->getPage()->attachFileToField($field, $path);


### PR DESCRIPTION
I was trying to attach a file to a field and the step "passed" then I saw that the file was actually not attached, after a quick check I figured out that the file was deleted but I got the step "passing". I've decided that it will be a good idea to add an exception when the file you are trying to attach is not found.

This is realted to 'attachFileToField' function.