### PR TITLE
Fixes #266: Stop sessions if exception thrown when resetting

### DIFF
--- a/src/Behat/MinkExtension/Listener/SessionsListener.php
+++ b/src/Behat/MinkExtension/Listener/SessionsListener.php
@@ -101,7 +101,12 @@ class SessionsListener implements EventSubscriberInterface
         if ($scenario->hasTag('insulated') || $feature->hasTag('insulated')) {
             $this->mink->stopSessions();
         } else {
-            $this->mink->resetSessions();
+            try {
+                $this->mink->resetSessions();
+            }
+            catch (\Exception $e) {
+                $this->mink->stopSessions();
+            }
         }
 
         $this->mink->setDefaultSessionName($session);


### PR DESCRIPTION
A fix for #266 that works in my testing with a sporadic (but pretty reliable) Chrome crash