### PR TITLE
Xdebug support in PHPStorm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.phar
 composer.lock
 vendor
+.idea
+behat.yml

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -2,10 +2,12 @@ default:
   suites:
     default:
       path: %paths.base%/features
-      contexts: [Behat\MinkExtension\Context\MinkContext]
+      contexts:
+        - Behat\MinkExtension\Context\MinkContext
+        - Behat\MinkExtension\Tests\FeatureContext
   extensions:
     Behat\MinkExtension:
-      base_url: http://en.wikipedia.org/
+      base_url: http://localhost:8082
       sessions:
         default:
           goutte: ~

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
   "require-dev": {
     "phpspec/phpspec": "~2.0",
     "behat/mink-goutte-driver": "~1.1",
-    "internations/http-mock": "^0.10.0",
-    "phpunit/phpunit": "^6.2"
+    "internations/http-mock": "^0.10.0"
   },
   "autoload": {
     "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -1,40 +1,50 @@
 {
-    "name": "behat/mink-extension",
-    "type": "behat-extension",
-    "description": "Mink extension for Behat",
-    "keywords": ["web", "test", "browser", "gui"],
-    "homepage": "http://extensions.behat.org/mink",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Konstantin Kudryashov",
-            "email": "ever.zet@gmail.com"
-        },
-        {
-            "name": "Christophe Coevoet",
-            "email": "stof@notk.org"
-        }
-    ],
-
-    "require": {
-        "php":          ">=5.3.2",
-        "behat/behat":  "~3.0,>=3.0.5",
-        "behat/mink":   "~1.5",
-        "symfony/config": "~2.2|~3.0"
+  "name": "behat/mink-extension",
+  "type": "behat-extension",
+  "description": "Mink extension for Behat",
+  "keywords": [
+    "web",
+    "test",
+    "browser",
+    "gui"
+  ],
+  "homepage": "http://extensions.behat.org/mink",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Konstantin Kudryashov",
+      "email": "ever.zet@gmail.com"
     },
-
-    "require-dev": {
-        "phpspec/phpspec":          "~2.0",
-        "behat/mink-goutte-driver": "~1.1"
-    },
-
-    "autoload": {
-        "psr-0": { "Behat\\MinkExtension": "src/" }
-    },
-
-    "extra": {
-        "branch-alias": {
-            "dev-master": "2.1.x-dev"
-        }
+    {
+      "name": "Christophe Coevoet",
+      "email": "stof@notk.org"
     }
+  ],
+  "require": {
+    "php": ">=5.3.2",
+    "behat/behat": "~3.0,>=3.0.5",
+    "behat/mink": "~1.5",
+    "symfony/config": "~2.2|~3.0"
+  },
+  "require-dev": {
+    "phpspec/phpspec": "~2.0",
+    "behat/mink-goutte-driver": "~1.1",
+    "internations/http-mock": "^0.10.0",
+    "phpunit/phpunit": "^6.2"
+  },
+  "autoload": {
+    "psr-0": {
+      "Behat\\MinkExtension": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Behat\\MinkExtension\\Tests\\": "features/src"
+    }
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "2.1.x-dev"
+    }
+  }
 }

--- a/features/search.feature
+++ b/features/search.feature
@@ -4,13 +4,13 @@ Feature: Search
   I need to be able to search for a word
 
   Scenario: Searching for a page that does exist
-    Given I am on "/wiki/Main_Page"
+    Given I am on "http://en.wikipedia.org/wiki/Main_Page"
     When I fill in "search" with "Behavior Driven Development"
     And I press "searchButton"
     Then I should see "agile software development"
 
   Scenario: Searching for a page that does NOT exist
-    Given I am on "/wiki/Main_Page"
+    Given I am on "http://en.wikipedia.org/wiki/Main_Page"
     When I fill in "search" with "Glory Driven Development"
     And I press "searchButton"
     Then I should see "Search results"

--- a/features/src/FeatureContext.php
+++ b/features/src/FeatureContext.php
@@ -9,78 +9,83 @@ use InterNations\Component\HttpMock\PHPUnit\HttpMockTrait;
 /**
  * Feature context for testing advanced scenarios.
  */
-class FeatureContext extends RawMinkContext {
+class FeatureContext extends RawMinkContext
+{
 
-  use HttpMockTrait;
+    use HttpMockTrait;
 
-  /**
-   * @BeforeScenario
-   */
-  public function setUp() {
-    static::setUpHttpMockBeforeClass('8082', 'localhost');
-    $this->setUpHttpMock();
+    /**
+     * @BeforeScenario
+     */
+    public function setUp()
+    {
+        static::setUpHttpMockBeforeClass('8082', 'localhost');
+        $this->setUpHttpMock();
 
-    $this->http->mock->when()
-      ->methodIs('GET')
-      ->pathIs('/foo')
-      ->then()
-      ->body('Request body')
-      ->end();
-    $this->http->setUp();
-  }
-
-  /**
-   * @AfterScenario
-   */
-  public function tearDown() {
-    static::tearDownHttpMockAfterClass();
-    $this->tearDownHttpMock();
-  }
-
-  /**
-   * @BeforeScenario @xdebug
-   */
-  public function setUpXdebug() {
-    $this->getSession()->setCookie('XDEBUG_SESSION_START', 'xdebug');
-  }
-
-  /**
-   * Mocking the phpunit assertion as it is used by HttpMockTrait.
-   */
-  public static function assertSame($message, $argument_1, $argument_2) {
-    return $argument_1 !== $argument_2;
-  }
-
-  /**
-   * @Then /^I should have the "([^"]*)" cookie with value "([^"]*)"$/
-   */
-  public function iShouldHaveTheCookieWithValue($cookie_name, $cookie_expected_value) {
-    if ($cookie_real_value = $this->getSession()->getCookie($cookie_name)) {
-      if ($cookie_real_value !== $cookie_expected_value) {
-        throw new ExpectationException(
-          'The cookie with name ' . $cookie_name . ' was found, but does not contain ' . $cookie_real_value . ', yet it contains ' . $cookie_expected_value . '.',
-          $this->getSession()
-        );
-      }
+        $this->http->mock->when()
+          ->methodIs('GET')
+          ->pathIs('/foo')
+          ->then()
+          ->body('Request body')
+          ->end();
+        $this->http->setUp();
     }
-    else {
-      throw new ExpectationException(
-        'The cookie with name ' . $cookie_name . ' was not found',
-        $this->getSession()
-      );
-    }
-  }
 
-  /**
-   * @Then /^I should not have the "([^"]*)" cookie$/
-   */
-  public function iShouldNotHaveTheCookie($cookie_name) {
-    if ($cookie_real_value = $this->getSession()->getCookie($cookie_name)) {
-      throw new ExpectationException(
-        'The cookie with name ' . $cookie_name . ' was not found, but it should not be present.',
-        $this->getSession()
-      );
+    /**
+     * @AfterScenario
+     */
+    public function tearDown()
+    {
+        static::tearDownHttpMockAfterClass();
+        $this->tearDownHttpMock();
     }
-  }
+
+    /**
+     * @BeforeScenario @MockXdebug
+     */
+    public function setUpXdebugMock()
+    {
+        $_SERVER['XDEBUG_CONFIG'] = 'xdebug';
+    }
+
+    /**
+     * Mocking the phpunit assertion as it is used by HttpMockTrait.
+     */
+    public static function assertSame($message, $argument_1, $argument_2)
+    {
+        return $argument_1 !== $argument_2;
+    }
+
+    /**
+     * @Then /^I should have the "([^"]*)" cookie with value "([^"]*)"$/
+     */
+    public function iShouldHaveTheCookieWithValue($cookie_name, $cookie_expected_value) {
+        if ($cookie_real_value = $this->getSession()->getCookie($cookie_name)) {
+            if ($cookie_real_value !== $cookie_expected_value) {
+                throw new ExpectationException(
+                  'The cookie with name ' . $cookie_name . ' was found, but does not contain ' . $cookie_real_value . ', yet it contains ' . $cookie_expected_value . '.',
+                  $this->getSession()
+                );
+            }
+        } else {
+            throw new ExpectationException(
+              'The cookie with name ' . $cookie_name . ' was not found',
+              $this->getSession()
+            );
+        }
+    }
+
+    /**
+     * @Then /^I should not have the "([^"]*)" cookie$/
+     */
+    public function iShouldNotHaveTheCookie($cookie_name)
+    {
+        if ($cookie_real_value = $this->getSession()->getCookie($cookie_name)) {
+            throw new ExpectationException(
+              'The cookie with name ' . $cookie_name . ' was not found, but it should not be present.',
+              $this->getSession()
+            );
+        }
+    }
 
 }

--- a/features/src/FeatureContext.php
+++ b/features/src/FeatureContext.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Behat\MinkExtension\Tests;
+
+use Behat\Mink\Exception\ExpectationException;
+use Behat\MinkExtension\Context\RawMinkContext;
+use InterNations\Component\HttpMock\PHPUnit\HttpMockTrait;
+
+/**
+ * Feature context for testing advanced scenarios.
+ */
+class FeatureContext extends RawMinkContext {
+
+  use HttpMockTrait;
+
+  /**
+   * @BeforeScenario
+   */
+  public function setUp() {
+    static::setUpHttpMockBeforeClass('8082', 'localhost');
+    $this->setUpHttpMock();
+
+    $this->http->mock->when()
+      ->methodIs('GET')
+      ->pathIs('/foo')
+      ->then()
+      ->body('Request body')
+      ->end();
+    $this->http->setUp();
+  }
+
+  /**
+   * @AfterScenario
+   */
+  public function tearDown() {
+    static::tearDownHttpMockAfterClass();
+    $this->tearDownHttpMock();
+  }
+
+  /**
+   * @BeforeScenario @xdebug
+   */
+  public function setUpXdebug() {
+    $this->getSession()->setCookie('XDEBUG_SESSION_START', 'xdebug');
+  }
+
+  /**
+   * Mocking the phpunit assertion as it is used by HttpMockTrait.
+   */
+  public static function assertSame($message, $argument_1, $argument_2) {
+    return $argument_1 !== $argument_2;
+  }
+
+  /**
+   * @Then /^I should have the "([^"]*)" cookie with value "([^"]*)"$/
+   */
+  public function iShouldHaveTheCookieWithValue($cookie_name, $cookie_expected_value) {
+    if ($cookie_real_value = $this->getSession()->getCookie($cookie_name)) {
+      if ($cookie_real_value !== $cookie_expected_value) {
+        throw new ExpectationException(
+          'The cookie with name ' . $cookie_name . ' was found, but does not contain ' . $cookie_real_value . ', yet it contains ' . $cookie_expected_value . '.',
+          $this->getSession()
+        );
+      }
+    }
+    else {
+      throw new ExpectationException(
+        'The cookie with name ' . $cookie_name . ' was not found',
+        $this->getSession()
+      );
+    }
+  }
+
+  /**
+   * @Then /^I should not have the "([^"]*)" cookie$/
+   */
+  public function iShouldNotHaveTheCookie($cookie_name) {
+    if ($cookie_real_value = $this->getSession()->getCookie($cookie_name)) {
+      throw new ExpectationException(
+        'The cookie with name ' . $cookie_name . ' was not found, but it should not be present.',
+        $this->getSession()
+      );
+    }
+  }
+
+}

--- a/features/xdebug.feature
+++ b/features/xdebug.feature
@@ -1,0 +1,17 @@
+Feature: Xdebug
+  In order to properly develop with BDD
+  As a feature developer
+  I need to be able to use my debugger
+
+  Scenario: Xdebug cookie should not be present on normal requests
+    Given I am on "/foo"
+    Then I should not have the "XDEBUG_SESSION_START" cookie
+
+  @xdebug
+  Scenario: Xdebug cookie should be passed on to requests
+    Given I am on "/foo"
+    Then I should have the "XDEBUG_SESSION_START" cookie with value "xdebug"
+
+  Scenario: When running php with xdebug from the command line the cookie should be set
+    Given I am on "/foo"
+    Then I should have the "XDEBUG_SESSION_START" cookie with value "xdebug"

--- a/features/xdebug.feature
+++ b/features/xdebug.feature
@@ -5,13 +5,9 @@ Feature: Xdebug
 
   Scenario: Xdebug cookie should not be present on normal requests
     Given I am on "/foo"
-    Then I should not have the "XDEBUG_SESSION_START" cookie
+    Then I should not have the "XDEBUG_SESSION" cookie
 
-  @xdebug
+  @MockXdebug
   Scenario: Xdebug cookie should be passed on to requests
     Given I am on "/foo"
-    Then I should have the "XDEBUG_SESSION_START" cookie with value "xdebug"
-
-  Scenario: When running php with xdebug from the command line the cookie should be set
-    Given I am on "/foo"
-    Then I should have the "XDEBUG_SESSION_START" cookie with value "xdebug"
+    Then I should have the "XDEBUG_SESSION" cookie with value "xdebug"

--- a/src/Behat/MinkExtension/Context/RawMinkContext.php
+++ b/src/Behat/MinkExtension/Context/RawMinkContext.php
@@ -25,7 +25,6 @@ class RawMinkContext implements MinkAwareContext
     private $mink;
     private $minkParameters;
 
-
     /**
      * Currently supports PHPSTORM.
      *

--- a/src/Behat/MinkExtension/Context/RawMinkContext.php
+++ b/src/Behat/MinkExtension/Context/RawMinkContext.php
@@ -25,6 +25,19 @@ class RawMinkContext implements MinkAwareContext
     private $mink;
     private $minkParameters;
 
+
+    /**
+     * Currently supports PHPSTORM.
+     *
+     * @beforeScenario
+     */
+    public function setUpXdebugIfIdeIsConfigured()
+    {
+        if (isset($_SERVER['XDEBUG_CONFIG'])) {
+            $this->getSession()->setCookie('XDEBUG_SESSION', 'xdebug');
+        }
+    }
+
     /**
      * Sets Mink instance.
      *


### PR DESCRIPTION
Hi,

This is an initial proposal to add PHPstorm xdebug integration.

Current situation is that, you can debug behat as long as calls are direct, however, once http requests are involved like `When I am on "\"` then the debugger will no longer continue as no cookie is set.

This pull requests solves this by checking if the xdebug_config server variable is set, if that is the case, the session will receive the xdebug cookie allowing the debugger to work.

I have included internations/http-mock to mock a php webserver, we could update the other feature to use this as well. But let's handle that separate.

Suggestions are welcome.