### PR TITLE
Added "tunnel_autodiscover" setting for NOT setting tunnel-identifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.phar
 composer.lock
 vendor
+.idea/

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "behat/mink-extension",
+    "name": "ogprogrammer/mink-extension",
     "type": "behat-extension",
     "description": "Mink extension for Behat",
     "keywords": ["web", "test", "browser", "gui"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ogprogrammer/mink-extension",
+    "name": "behat/mink-extension",
     "type": "behat-extension",
     "description": "Mink extension for Behat",
     "keywords": ["web", "test", "browser", "gui"],

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -347,3 +347,6 @@ There's other useful parameters, that you can use to configure your suite:
   name.
 * ``mink_loader`` - path to a file loaded to make Mink available (useful when
   using the PHAR archive for Mink, useless when using Composer)
+* ``tunnel_autodiscovery`` - If Jenkins is having issues connecting to Sauce Labs,
+  it is probably because the tunnel-identifier is getting set to a bad value.
+  Set this to false to bypass autodiscovery of tunnel-identifier.

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/Selenium2Factory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/Selenium2Factory.php
@@ -68,7 +68,7 @@ class Selenium2Factory implements DriverFactory
                 'tags' => array('Travis-CI', 'PHP '.phpversion())
             );
 
-            if ($config['tunnel_autodiscovery']) {
+            if (isset($config['tunnel_autodiscovery']) && $config['tunnel_autodiscovery']) {
                 $guessedCapabilities['tunnel-identifier'] = getenv('TRAVIS_JOB_NUMBER');
             }
 
@@ -78,7 +78,7 @@ class Selenium2Factory implements DriverFactory
                 'tags' => array('Jenkins', 'PHP '.phpversion(), getenv('BUILD_TAG'))
             );
 
-            if ($config['tunnel_autodiscovery']) {
+            if (isset($config['tunnel_autodiscovery']) && $config['tunnel_autodiscovery']) {
                 $guessedCapabilities['tunnel-identifier'] = getenv('JOB_NAME');
             }
 

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/Selenium2Factory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/Selenium2Factory.php
@@ -41,6 +41,7 @@ class Selenium2Factory implements DriverFactory
                 ->scalarNode('browser')->defaultValue('%mink.browser_name%')->end()
                 ->append($this->getCapabilitiesNode())
                 ->scalarNode('wd_host')->defaultValue('http://localhost:4444/wd/hub')->end()
+                ->booleanNode('tunnel_autodiscovery')->defaultTrue()->end()
             ->end()
         ;
     }
@@ -61,17 +62,26 @@ class Selenium2Factory implements DriverFactory
         unset($config['capabilities']['extra_capabilities']);
 
         if (getenv('TRAVIS_JOB_NUMBER')) {
+
             $guessedCapabilities = array(
-                'tunnel-identifier' => getenv('TRAVIS_JOB_NUMBER'),
                 'build' => getenv('TRAVIS_BUILD_NUMBER'),
-                'tags' => array('Travis-CI', 'PHP '.phpversion()),
+                'tags' => array('Travis-CI', 'PHP '.phpversion())
             );
+
+            if ($config['tunnel_autodiscovery']) {
+                $guessedCapabilities['tunnel-identifier'] = getenv('TRAVIS_JOB_NUMBER');
+            }
+
         } elseif (getenv('JENKINS_HOME')) {
             $guessedCapabilities = array(
-                'tunnel-identifier' => getenv('JOB_NAME'),
                 'build' => getenv('BUILD_NUMBER'),
-                'tags' => array('Jenkins', 'PHP '.phpversion(), getenv('BUILD_TAG')),
+                'tags' => array('Jenkins', 'PHP '.phpversion(), getenv('BUILD_TAG'))
             );
+
+            if ($config['tunnel_autodiscovery']) {
+                $guessedCapabilities['tunnel-identifier'] = getenv('JOB_NAME');
+            }
+
         } else {
             $guessedCapabilities = array(
                 'tags' => array(php_uname('n'), 'PHP '.phpversion()),


### PR DESCRIPTION
This fix addresses an issue I found when setting up Jenkins to run my Behat tests. I am not using any jenkins plugins to manage my sauce labs connection. Instead I am letting the webdriver establish a session without the need for a proxy. When I ran tests by hand on the jenkins server, the tests ran fine. However, when I ran them with jenkins, an area of code was setting the tunnel-identifier to some bogus value. This fix basically allows me to tell behat to tell the selenium2driver NOT to "autodiscover" the tunnel. Without dodging this tunnel-identifier set, I got the following from Jenkins/Behat

> could not open connection: Sauce could not start your job.

![screen shot 2017-08-14 at 11 13 51 am](https://user-images.githubusercontent.com/985151/29295294-83856358-8108-11e7-9511-4e9e4dea377a.png)

I may have done this in a way that breaks BC or something so I need some eyes on how to improve this to get into mainline so I can migrate back off my fork.