### PR TITLE
Improve the Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,30 +7,28 @@ cache:
     - $HOME/.composer/cache/files
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
-  - hhvm
+  - 7.0
+  - 7.1
+  - nightly
 
 matrix:
   include:
-    - php: 5.5
-      env: SYMFONY_VERSION='2.3.*'
+    - php: 5.3
+      dist: precise
     # Test against dev dependencies
-    - php: 5.6
+    - php: 7.1
       env: DEPS=dev
 
 before_install:
-  - composer self-update
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi;
   - if [ "$DEPS" = 'dev' ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
 
 install:
   - composer install --no-progress
 
 before_script:
-  - export PATH=./vendor/bin:$PATH
   - export PATH=./vendor/bin:$PATH
 
 script:


### PR DESCRIPTION
- Fix the PHP 5.3 job
- Add testing on PHP 7
- Remove testing on Symfony 2.3 (which is EOLed)
- Remove testing on HHVM (as they announced the end of support of PHP compat)

Closes #290