### PR TITLE
Remove ancient PHP versions from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,12 @@ cache:
     - $HOME/.composer/cache/files
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
   - hhvm
 
 matrix:
   include:
-    - php: 5.5
+    - php: 5.6
       env: SYMFONY_VERSION='2.3.*'
     # Test against dev dependencies
     - php: 5.6


### PR DESCRIPTION
The PHP 5.3 job fails because PHP 5.3 does not exist in the Travis system.
So for starters get rid of ancient PHP versions from the build/test matrix.