### PR TITLE
Added WebDriver Capabilities from W3 Recommendation: acceptInsecureCerts & pageLoadStrategy

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -235,6 +235,42 @@ with support for 7 drivers out of the box:
                         my_session:
                             selenium2: ~
 
+
+  .. Tips : HTTPS and self-signed certificate
+  If you use Behat/Mink/Selenium2 to test your application, and want to test an
+  application secured with HTTPS, but with a self-signed certificate, you can use
+  the following parameters to avoid the validation error:
+
+  * For ``Firefox``:
+  
+      .. code-block:: yaml
+
+          default:
+              extensions:
+                  Behat\MinkExtension:
+                    sessions:
+                        my_session:
+                            selenium2:
+                              browser: firefox
+                              capabilities: { "browserName": "firefox", "browser": "firefox", "version":  "", "acceptInsecureCerts" : true}
+
+
+  * For ``Chrome``:
+  
+      .. code-block:: yaml
+
+          default:
+              extensions:
+                  Behat\MinkExtension:
+                    sessions:
+                        my_session:
+                            selenium2:
+                              browser: chrome
+                              capabilities: { "browserName": "chrome", "browser": "chrome", "version":  "", "acceptInsecureCerts" : true}
+
+
+
+
 * ``SauceLabsDriver`` - special flavor of the Selenium2Driver configured to use the
   selenium2 hosted installation of saucelabs.com. In order to use it, modify your
   ``behat.yml`` profile:

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/Selenium2Factory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/Selenium2Factory.php
@@ -111,6 +111,11 @@ class Selenium2Factory implements DriverFactory
                 ->booleanNode('webStorageEnabled')->end()
                 ->booleanNode('rotatable')->end()
                 ->booleanNode('acceptSslCerts')->end()
+                // https://github.com/mozilla/geckodriver#webdriver-capabilities
+                // https://www.w3.org/TR/webdriver/#dfn-accept-insecure-tls-certificates
+                ->booleanNode('acceptInsecureCerts')->end()
+                // https://github.com/mozilla/geckodriver#webdriver-capabilities
+                ->scalarNode('pageLoadStrategy')->defaultValue('normal')->end()
                 ->booleanNode('nativeEvents')->end()
                 ->booleanNode('overlappingCheckDisabled')->end()
                 ->arrayNode('proxy')


### PR DESCRIPTION
Sers,
in this pull request the Selenium2-WebDriver got updated to allow the following additional capabilities:
- pageLoadStrategy
- acceptInsecureCerts

See
- https://www.w3.org/TR/webdriver/#capabilities
- https://www.w3.org/TR/webdriver/#dfn-accept-insecure-tls-certificates

Furthermore the documentation now also contains an example on how to configure firefox and chrome to ignore SSL Certificate Errors (self signed certificates for example)

hth