### PR TITLE
BrowserStack requires realMobile flag to run tests on real devices

### DIFF
--- a/src/Behat/MinkExtension/ServiceContainer/Driver/BrowserStackFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/BrowserStackFactory.php
@@ -62,6 +62,8 @@ class BrowserStackFactory extends Selenium2Factory
                 ->booleanNode('browserstack-debug')->end()
                 ->booleanNode('browserstack-tunnel')->end()
                 ->booleanNode('emulator')->end()
+                ->booleanNode('real_mobile')->end()
+                ->booleanNode('realMobile')->end()
                 ->booleanNode('acceptSslCert')->end()
             ->end()
         ;


### PR DESCRIPTION
[Documentation on BrowserStack](https://www.browserstack.com/automate/capabilities#mobile-capabilities)

Both variants (`real_mobile` and `realMobile`) are supported