### PR TITLE
Accept insecure certs for headless chrome

### DIFF
--- a/src/Behat/MinkExtension/ServiceContainer/Driver/Selenium2Factory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/Selenium2Factory.php
@@ -111,6 +111,7 @@ class Selenium2Factory implements DriverFactory
                 ->booleanNode('webStorageEnabled')->end()
                 ->booleanNode('rotatable')->end()
                 ->booleanNode('acceptSslCerts')->end()
+                ->booleanNode('acceptInsecureCerts')->end()
                 ->booleanNode('nativeEvents')->end()
                 ->booleanNode('overlappingCheckDisabled')->end()
                 ->arrayNode('proxy')


### PR DESCRIPTION
Allow to ignore ssl certificates for headless chrome, chrome-driver in the latest versions with Selenium2 driver