### PR TITLE
Remove brackets from echo call and use PHP_EOL over \n

### DIFF
--- a/src/Behat/MinkExtension/Context/MinkContext.php
+++ b/src/Behat/MinkExtension/Context/MinkContext.php
@@ -515,10 +515,8 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      */
     public function printLastResponse()
     {
-        echo (
-            $this->getSession()->getCurrentUrl()."\n\n".
-            $this->getSession()->getPage()->getContent()
-        );
+        echo $this->getSession()->getCurrentUrl() . PHP_EOL . PHP_EOL
+            . $this->getSession()->getPage()->getContent();
     }
 
     /**

--- a/src/Behat/MinkExtension/Context/MinkContext.php
+++ b/src/Behat/MinkExtension/Context/MinkContext.php
@@ -515,7 +515,7 @@ class MinkContext extends RawMinkContext implements TranslatableContext
      */
     public function printLastResponse()
     {
-        echo $this->getSession()->getCurrentUrl() . PHP_EOL . PHP_EOL
+        echo $this->getSession()->getCurrentUrl() . "\n\n"
             . $this->getSession()->getPage()->getContent();
     }
 


### PR DESCRIPTION
echo is a language construct rather than a function, so shouldn't really have brackets when called. Also switched to using a platform agnostic new line.