### PR TITLE
 Add MinkPantherDriver support

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -178,7 +178,7 @@ Drivers
 ~~~~~~~
 
 First of all, there are drivers enabling configuration. MinkExtension comes
-with support for 7 drivers out of the box:
+with support for 8 drivers out of the box:
 
 * ``GoutteDriver`` - headless driver without JavaScript support. In order to use
   it, modify your ``behat.yml`` profile:
@@ -234,6 +234,18 @@ with support for 7 drivers out of the box:
                     sessions:
                         my_session:
                             selenium2: ~
+
+* ``PantherDriver`` - javascript driver based on symfony/panther. In order to use it, modify your
+  ``behat.yml`` profile:
+
+    .. code-block:: yaml
+
+        default:
+            extensions:
+                Behat\MinkExtension:
+                    sessions:
+                        my_session:
+                            panther: ~
 
 * ``SauceLabsDriver`` - special flavor of the Selenium2Driver configured to use the
   selenium2 hosted installation of saucelabs.com. In order to use it, modify your

--- a/spec/Behat/MinkExtension/ServiceContainer/Driver/PantherFactorySpec.php
+++ b/spec/Behat/MinkExtension/ServiceContainer/Driver/PantherFactorySpec.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace spec\Behat\MinkExtension\ServiceContainer\Driver;
+
+use PhpSpec\ObjectBehavior;
+
+class PantherFactorySpec extends ObjectBehavior
+{
+    function it_is_a_driver_factory()
+    {
+        $this->shouldHaveType('Behat\MinkExtension\ServiceContainer\Driver\DriverFactory');
+    }
+
+    function it_is_named_goutte()
+    {
+        $this->getDriverName()->shouldReturn('panther');
+    }
+
+    function it_does_not_support_javascript()
+    {
+        $this->supportsJavascript()->shouldBe(true);
+    }
+}

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/PantherFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/PantherFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Behat MinkExtension.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\MinkExtension\ServiceContainer\Driver;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * @author Robert Freigang <robertfreigang@gmx.de>
+ */
+class PantherFactory implements DriverFactory
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDriverName()
+    {
+        return 'panther';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsJavascript()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(ArrayNodeDefinition $builder)
+    {
+        $builder
+            ->children()
+                ->arrayNode('options')
+                    ->useAttributeAsKey('key')
+                    ->prototype('variable')->end()
+                    ->info(
+                        "These are the options passed as first argument to PantherTestcaseTrait::createPantherClient client constructor."
+                    )
+                ->end()
+            ->end()
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildDriver(array $config)
+    {
+        if (!class_exists('Behat\Mink\Driver\PantherDriver')) {
+            throw new \RuntimeException(
+                'Install MinkPantherDriver in order to use panther driver.'
+            );
+        }
+
+        return new Definition(
+            'Behat\Mink\Driver\PantherDriver',
+            array(
+                'panther', $config['options']
+            )
+        );
+    }
+}

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/PantherFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/PantherFactory.php
@@ -66,7 +66,7 @@ class PantherFactory implements DriverFactory
         return new Definition(
             'Behat\Mink\Driver\PantherDriver',
             array(
-                'panther', $config['options']
+                $config['options']
             )
         );
     }

--- a/src/Behat/MinkExtension/ServiceContainer/MinkExtension.php
+++ b/src/Behat/MinkExtension/ServiceContainer/MinkExtension.php
@@ -15,6 +15,7 @@ use Behat\MinkExtension\ServiceContainer\Driver\AppiumFactory;
 use Behat\MinkExtension\ServiceContainer\Driver\BrowserStackFactory;
 use Behat\MinkExtension\ServiceContainer\Driver\DriverFactory;
 use Behat\MinkExtension\ServiceContainer\Driver\GoutteFactory;
+use Behat\MinkExtension\ServiceContainer\Driver\PantherFactory;
 use Behat\MinkExtension\ServiceContainer\Driver\SahiFactory;
 use Behat\MinkExtension\ServiceContainer\Driver\SauceLabsFactory;
 use Behat\MinkExtension\ServiceContainer\Driver\Selenium2Factory;
@@ -58,6 +59,7 @@ class MinkExtension implements ExtensionInterface
         $this->registerDriverFactory(new BrowserStackFactory());
         $this->registerDriverFactory(new ZombieFactory());
         $this->registerDriverFactory(new AppiumFactory());
+        $this->registerDriverFactory(new PantherFactory());
     }
 
     public function registerDriverFactory(DriverFactory $driverFactory)


### PR DESCRIPTION
MinkPantherDriver is currently under namespace ```robertfausk/MinkPantherDriver```.

For installation you will need to ```composer require --dev robertfausk/MinkPantherDriver``` or look at [robertfausk/MinkPantherDriver](https://github.com/robertfausk/MinkPantherDriver).