### PR TITLE
Fix PHP8 deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 8.0
   - hhvm
 
 matrix:
@@ -25,6 +26,8 @@ matrix:
       env: SYMFONY_VERSION='^3'
     # Test against dev dependencies
     - php: 7.2
+      env: DEPS=dev
+    - php: 8.0
       env: DEPS=dev
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 
     "require-dev": {
         "behat/mink-goutte-driver": "^1.1",
-        "phpspec/phpspec":          "^2.0"
+        "phpspec/phpspec":          "^7.0"
     },
 
     "autoload": {

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php
@@ -115,8 +115,9 @@ class GoutteFactory implements DriverFactory
     private function isGoutte1()
     {
         $refl = new \ReflectionParameter(array('Goutte\Client', 'setClient'), 0);
+        $type = $refl->getType();
 
-        if ($refl->getClass() && 'Guzzle\Http\ClientInterface' === $refl->getClass()->getName()) {
+        if ($type instanceof \ReflectionNamedType && 'Guzzle\Http\ClientInterface' === $type->getName()) {
             return true;
         }
 

--- a/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php
@@ -115,13 +115,11 @@ class GoutteFactory implements DriverFactory
     private function isGoutte1()
     {
         $refl = new \ReflectionParameter(array('Goutte\Client', 'setClient'), 0);
-        $type = $refl->getType();
-
-        if ($type instanceof \ReflectionNamedType && 'Guzzle\Http\ClientInterface' === $type->getName()) {
-            return true;
+        if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+          return $refl->getClass() && 'Guzzle\Http\ClientInterface' === $refl->getClass()->getName();
         }
 
-        return false;
+        return $refl->getType() instanceof \ReflectionNamedType && 'Guzzle\Http\ClientInterface' === $refl->getType()->getName();
     }
 
     private function isGuzzle6()


### PR DESCRIPTION
When run behat with PHP8 it shown next deprecation warning:
```
$ behat
PHP Deprecated:  Method ReflectionParameter::getClass() is deprecated in /var/www/html/vendor/behat/mink-extension/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php on line 119
```