### PR TITLE
DEP Require symfony ^6.1 and PHP ^8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     ],
 
     "require": {
-        "php":          ">=5.3.2",
+        "php":          "^8.1",
         "behat/behat":  "^3.0.5",
         "behat/mink":   "^1.5",
-        "symfony/config": "^2.7|^3.0|^4.0"
+        "symfony/config": "^6.1"
     },
 
     "require-dev": {


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10389

I've forked https://github.com/Behat/MinkExtension because it lacks symfony 6 support

I'll update silverstripe/behat-extension `5` to use this fork
