### PR TITLE
Cast base_url to string to avoid warning on PHP 8.1

### DIFF
--- a/src/Behat/MinkExtension/Context/RawMinkContext.php
+++ b/src/Behat/MinkExtension/Context/RawMinkContext.php
@@ -141,7 +141,7 @@ class RawMinkContext implements MinkAwareContext
      */
     public function locatePath($path)
     {
-        $startUrl = rtrim($this->getMinkParameter('base_url'), '/') . '/';
+        $startUrl = rtrim((string)$this->getMinkParameter('base_url'), '/') . '/';
 
         return 0 !== strpos($path, 'http') ? $startUrl . ltrim($path, '/') : $path;
     }


### PR DESCRIPTION
On PHP 8.1, when no base_url is set, a warning is triggered because `rtrim()` expects a string as first argument.